### PR TITLE
Modernize NoteScaler to .NET 10 and shared CI/CD

### DIFF
--- a/.github/workflows/dotnet-10-ci.yml
+++ b/.github/workflows/dotnet-10-ci.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build-and-test:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/dotnet-10-ci.yml
+++ b/.github/workflows/dotnet-10-ci.yml
@@ -1,0 +1,35 @@
+name: .NET 10 CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore NoteScaler.sln
+
+      - name: Build
+        run: dotnet build NoteScaler.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test NoteScaler.sln --configuration Release --no-build --verbosity normal

--- a/.github/workflows/dotnet-10-ci.yml
+++ b/.github/workflows/dotnet-10-ci.yml
@@ -1,35 +1,69 @@
-name: .NET 10 CI
+name: CI / Build / Release
 
 on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '**/*.md'
+      - '.github/workflows/**'
+
   push:
     branches:
       - master
+    tags:
+      - 'v*.*.*.*'
+    paths-ignore:
+      - '**/*.md'
+      - '.github/workflows/**'
 
-permissions:
-  contents: read
+  workflow_dispatch:
 
 jobs:
-  build-and-test:
-    name: Build and test
-    runs-on: windows-latest
+  ci:
+    name: CI (Tests + Coverage)
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ScottyMac52/shared-github-workflows/.github/workflows/reusable-build-and-release.yml@main
+    with:
+      dotnet_version: '10.0.x'
+      run_tests: true
+      run_coverage: true
+      run_build_release: false
+      ci_mode: true
+      create_release: false
+      enable_installer: false
+    secrets: inherit
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+  build-on-master:
+    name: Build on Master
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+    uses: ScottyMac52/shared-github-workflows/.github/workflows/reusable-build-and-release.yml@main
+    with:
+      dotnet_version: '10.0.x'
+      run_tests: true
+      run_coverage: true
+      run_build_release: true
+      ci_mode: false
+      create_release: false
+      enable_installer: false
+    secrets: inherit
 
-      - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Restore
-        run: dotnet restore NoteScaler.sln
-
-      - name: Build
-        run: dotnet build NoteScaler.sln --configuration Release --no-restore
-
-      - name: Test
-        run: dotnet test NoteScaler.sln --configuration Release --no-build --verbosity normal
+  release:
+    name: Full Build + Release (Tag only)
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    uses: ScottyMac52/shared-github-workflows/.github/workflows/reusable-build-and-release.yml@main
+    with:
+      dotnet_version: '10.0.x'
+      run_tests: true
+      run_coverage: true
+      run_build_release: true
+      ci_mode: false
+      create_release: true
+      enable_installer: false
+    secrets: inherit

--- a/NoteScaler/NoteScaler.csproj
+++ b/NoteScaler/NoteScaler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Authors>Vyper Industries</Authors>
   </PropertyGroup>
 

--- a/NoteScaler/NoteScaler.csproj
+++ b/NoteScaler/NoteScaler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Authors>Vyper Industries</Authors>
   </PropertyGroup>
 

--- a/NoteScalerTests/NoteScalerTests.csproj
+++ b/NoteScalerTests/NoteScalerTests.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NoteScalerTests/NoteScalerTests.csproj
+++ b/NoteScalerTests/NoteScalerTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- retarget `NoteScaler` from `netcoreapp3.1` to `net10.0-windows`
- retarget `NoteScalerTests` to `net10.0-windows`
- update test infrastructure packages for .NET 10-compatible `dotnet test`
- replace the local CI implementation with a caller workflow that uses `ScottyMac52/shared-github-workflows/.github/workflows/reusable-build-and-release.yml@main`
- configure PR CI, master branch builds, and tag-only releases through the shared workflow

## Workflow behavior
- Pull requests into `master`: tests + coverage only (`ci_mode: true`)
- Pushes to `master`: build/test/coverage/package flow, no GitHub Release
- Tags matching `v*.*.*.*`: full build + release
- Markdown-only and workflow-only changes are ignored for normal PR/push triggers

## Validation
- Earlier local workflow passed after switching to `net10.0-windows` and `windows-latest`.
- The workflow now delegates to the shared CI/CD repo instead of duplicating restore/build/test steps locally.
- Latest caller workflow run is pending/starting after this update.

## Notes
- Draft PR only.
- No merge to `master`.