### PR TITLE
Phase 2 dependency cleanup and DI architecture

### DIFF
--- a/NoteScaler/Classes/PlayableSequence.cs
+++ b/NoteScaler/Classes/PlayableSequence.cs
@@ -14,6 +14,9 @@
 	/// </summary>
 	public class PlayableSequence
 	{
+		private readonly Func<IPlayer> notePlayerFactory;
+		private readonly Func<IStringInstrument> stringInstrumentFactory;
+
 		#region Public properties
 
 		public SongKey Song { get; protected set; }
@@ -36,13 +39,28 @@
 
 		#endregion Events
 
+		#region Constructors
+
+		public PlayableSequence()
+			: this(() => new SignalNotePlayer(), () => new Guitar())
+		{
+		}
+
+		public PlayableSequence(Func<IPlayer> notePlayerFactory, Func<IStringInstrument> stringInstrumentFactory)
+		{
+			this.notePlayerFactory = notePlayerFactory ?? throw new ArgumentNullException(nameof(notePlayerFactory));
+			this.stringInstrumentFactory = stringInstrumentFactory ?? throw new ArgumentNullException(nameof(stringInstrumentFactory));
+		}
+
+		#endregion Constructors
+
 		#region Public methods
 
 		public void Prepare()
 		{
-			NotePlayer = new SignalNotePlayer();
+			NotePlayer = notePlayerFactory();
 			NotePlayer.PlayerEvent += NotePlayer_PlayerEvent;
-			Guitar = new Guitar();
+			Guitar = stringInstrumentFactory();
 			PrepareSequence();
 		}
 

--- a/NoteScaler/NoteScaler.csproj
+++ b/NoteScaler/NoteScaler.csproj
@@ -38,10 +38,10 @@
 
   <ItemGroup>
     <PackageReference Include="BidirectionalMap" Version="1.0.0" />
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="NAudio" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/NoteScaler/Program.cs
+++ b/NoteScaler/Program.cs
@@ -1,219 +1,32 @@
 ﻿namespace NoteScaler
 {
-	using CommandLine;
-	using NoteScaler.Classes;
-	using NoteScaler.Config;
-	using NoteScaler.Enums;
-	using NoteScaler.Interfaces;
-	using NoteScaler.Models;
-	using System;
+	using Microsoft.Extensions.DependencyInjection;
+	using NoteScaler.Services;
+	using NoteScaler.Services.Interfaces;
 	using System.Diagnostics.CodeAnalysis;
-	using System.Linq;
-	using System.Threading;
 
 	[ExcludeFromCodeCoverage]
 	class Program
 	{
-		static int Main(string[] args)
+		public static int Main(string[] args)
 		{
-			var result = Parser.Default.ParseArguments<NoteScalerOptions>(args)
-				.WithParsed(o =>
-				{
-					MusicNote.FactoryError += MusicNote_FactoryError;
-					MusicNote.FactoryCreateNote += MusicNote_FactoryCreateNote;
-					InitializeNoteScalerOptions(o, out int a4Reference, out string key, out string fileName, out string tabName);
-					var playableSequence = CreatePlayableSequence(o, a4Reference);
-					PlayNoteAsRequired(o.Note, a4Reference, playableSequence);
-					PlayTabAsRequired(tabName, playableSequence);
-					PlaySongAsRequired(key, fileName, playableSequence);
-				});
-			return 0;
+			var serviceProvider = ConfigureServices();
+			var runner = serviceProvider.GetRequiredService<INoteScalerRunner>();
+			return runner.Run(args);
 		}
 
-		private static void MusicNote_FactoryCreateNote(object sender, EventArgs e)
+		private static ServiceProvider ConfigureServices()
 		{
-			var musicNote = sender as MusicNote;
-			WriteMessage($"Created: {musicNote.Key}{musicNote.DesiredOctave}", ConsoleColor.Green);
-		}
+			var services = new ServiceCollection();
 
-		private static void MusicNote_FactoryError(object sender, Exception e)
-		{
-			WriteMessage($"{e}", ConsoleColor.Red);
-		}
+			services.AddSingleton<ICommandLineOptionsService, CommandLineOptionsService>();
+			services.AddSingleton<IConsoleOutputService, ConsoleOutputService>();
+			services.AddSingleton<IPlayerFactory, SignalNotePlayerFactory>();
+			services.AddSingleton<IStringInstrumentFactory, StringInstrumentFactory>();
+			services.AddSingleton<IPlayableSequenceFactory, PlayableSequenceFactory>();
+			services.AddSingleton<INoteScalerRunner, NoteScalerRunner>();
 
-		private static PlayableSequence CreatePlayableSequence(NoteScalerOptions o, int a4Reference)
-		{
-			var playableSequence =  new PlayableSequence()
-			{
-				MeasureTime = o.Speed.GetValueOrDefault(),
-				Octave = o.Octave.GetValueOrDefault(),
-				A4Reference = a4Reference,
-				InstrumentType = o.Instrument
-			};
-
-			playableSequence.PlayableSequenceEvent += PlayableSequence_PlayableSequenceEvent;
-			return playableSequence;
-		}
-
-		private static void PlayableSequence_PlayableSequenceEvent(object sender, PlayableSequenceEvent e)
-		{
-			var textColor = ConsoleColor.White;
-			switch (e.EventType)
-			{
-				case PlayableEventType.StartSequence:
-				case PlayableEventType.CreateNote:
-					textColor = ConsoleColor.Blue;
-					break;
-				case PlayableEventType.SettingSequence:
-				case PlayableEventType.StopSequence:
-					textColor = ConsoleColor.Yellow;
-					break;
-				case PlayableEventType.PlayingNote:
-					textColor = ConsoleColor.Green;
-					break;
-				case PlayableEventType.Error:
-					textColor = ConsoleColor.Red;
-					break;
-				case PlayableEventType.SequenceLoaded:
-					textColor = ConsoleColor.White;
-					break;
-			}
-			WriteMessage($"Event: {e.EventType} -> {e.EventDetails}", textColor);
-		}
-
-		private static void InitializeNoteScalerOptions(NoteScalerOptions o, out int a4Reference, out string key, out string fileName, out string tabName)
-		{
-			key = o.Key;
-			fileName = o.File;
-			tabName = o.Tab;
-			var pause = o.Speed.GetValueOrDefault() * o.PreWait.GetValueOrDefault();
-			a4Reference = o.Range.GetValueOrDefault();
-			if (pause > 0)
-			{
-				WriteMessage($"Pausing {pause}ms prior to playing...");
-				Thread.Sleep(pause);
-			}
-		}
-
-		private static void PlayNoteAsRequired(string note, int a4Reference, PlayableSequence playableSequence)
-		{
-			if (note != null)
-			{
-				var musicNote = MusicNote.Create(note, a4Reference);
-				if (musicNote?.IsValid ?? false)
-				{
-					ShowNote(musicNote);
-					var musicNotes = musicNote.MajorScale.ToArray();
-					WriteMessage($"Playing Major Scale: {string.Join(',', musicNotes)}");
-					playableSequence.LoadSequenceFromString(musicNote.MajorScale);
-					playableSequence.Prepare();
-					playableSequence.Play();
-					Thread.Sleep(1000);
-					musicNotes = musicNote.MinorScale.ToArray();
-					WriteMessage($"Playing Minor Scale: {string.Join(',', musicNotes)}");
-					playableSequence.LoadSequenceFromString(musicNote.MinorScale);
-					playableSequence.Prepare();
-					playableSequence.Play();
-					Thread.Sleep(1000);
-					WriteMessage($"Playing Relative Minor Scale {musicNote.RelativeMinor}m: {string.Join(',', musicNote.RelativeMinorScale)}");
-					playableSequence.LoadSequenceFromString(musicNote.RelativeMinorScale);
-					playableSequence.Prepare();
-					playableSequence.Play();
-				}
-				else
-				{
-					WriteMessage($"{note} is NOT a valid note!", ConsoleColor.Red);
-				}
-			}
-		}
-
-		private static void PlaySongAsRequired(string key, string fileName, PlayableSequence playableSequence)
-		{
-			if (!string.IsNullOrEmpty(fileName))
-			{
-				var result = playableSequence.LoadFromFile(fileName, "Songs", out string errorString, out Song song);
-				if (!result)
-				{
-					WriteMessage(errorString, ConsoleColor.Red);
-				}
-				else
-				{
-					var currentSong = GetTheSongByKeyAsRequired(key, song);
-					playableSequence.ConvertSongNotesToNoteSequence(currentSong);
-					playableSequence.Prepare();
-					playableSequence.Play();
-
-					if(song.Reverse)
-					{
-						playableSequence.ReverseSequence();
-						playableSequence.Play();
-					}
-				}
-			}
-		}
-
-		private static void PlayTabAsRequired(string tabName, PlayableSequence playableSequence)
-		{
-			if (!string.IsNullOrEmpty(tabName))
-			{
-				var result = playableSequence.LoadFromFile(tabName, "Tabs", out string errorString, out Tablature tabs);
-				if (!result)
-				{
-					WriteMessage(errorString, ConsoleColor.Red);
-				}
-				else
-				{
-					tabs.FixUp();
-					IStringInstrument guitar = new Guitar(tabs.Tuning, 21);
-					playableSequence.ConvertTabsToNoteSequence(guitar, tabs);
-					playableSequence.Repeat = tabs.Repeat;
-					playableSequence.Prepare();
-					playableSequence.Play();
-			}
-			}
-		}
-
-		private static SongKey GetTheSongByKeyAsRequired(string key, Song song)
-		{
-			var currentSong = (SongKey) song;
-			if (!string.IsNullOrEmpty(key) && song.Keys.Any(songKey => songKey?.Name?.Equals(key) ?? false))
-			{
-				currentSong = song.Keys.SingleOrDefault(songKey => songKey?.Name?.Equals(key, StringComparison.InvariantCultureIgnoreCase) ?? false);
-			}
-			else
-			{
-				if(!string.IsNullOrEmpty(song.Name) && song.Keys != null)
-				{
-					currentSong = song.Keys.SingleOrDefault(songKey => songKey?.Name?.Equals(song.Name, StringComparison.InvariantCultureIgnoreCase) ?? false);
-				}
-			}
-
-			return currentSong;
-		}
-
-		private static void WriteMessage(string message, ConsoleColor textColor = ConsoleColor.White)
-		{
-			var currentForeground = Console.ForegroundColor;
-			Console.ForegroundColor = textColor;
-			Console.WriteLine(message);
-			Console.ForegroundColor = currentForeground;
-		}
-
-		private static void ShowNote(MusicNote musicNote)
-		{
-			var relativeMinor = musicNote.RelativeMinor;
-			var relativeMajor = musicNote.RelativeMajor;
-			WriteMessage($"{musicNote} is the current note");
-			WriteMessage($"Frequencies for this note are: {string.Join(',', musicNote.Frequencies.Select(f => f.ToString()))}");
-			WriteMessage($"Of the 12 natural, flat and sharp notes {musicNote} has {musicNote.NoteBefore} before it and {musicNote.NoteAfter} after it.");
-			WriteMessage($"Of the 7 notes in the {musicNote} scale {musicNote} has {musicNote.MajorNoteBefore} before it and {musicNote.MajorNoteAfter} after it.");
-			WriteMessage($"Of the 7 notes in the {musicNote}m scale {musicNote} has {musicNote.MinorNoteBefore} before it and {musicNote.MinorNoteAfter} after it.");
-			WriteMessage($"Notes in {musicNote} are: {string.Join(',', musicNote.MajorScale)}");
-			WriteMessage($"Notes in {musicNote}m are: {string.Join(',', musicNote.MinorScale)}");
-			WriteMessage($"Major Chord: {string.Join(',', musicNote.MajorChord15)} minor Chord: {string.Join(',', musicNote.MinorChord15)}");
-			WriteMessage($"The relative minor is {relativeMinor}m");
-			WriteMessage($"The relative minor scale is {string.Join(',', musicNote.RelativeMinorScale)}");
-			WriteMessage($"The relative Major to the minor is {relativeMajor}");
+			return services.BuildServiceProvider();
 		}
 	}
 }

--- a/NoteScaler/Services/CommandLineOptionsService.cs
+++ b/NoteScaler/Services/CommandLineOptionsService.cs
@@ -1,0 +1,15 @@
+namespace NoteScaler.Services
+{
+	using CommandLine;
+	using NoteScaler.Config;
+	using NoteScaler.Services.Interfaces;
+	using System.Collections.Generic;
+
+	public sealed class CommandLineOptionsService : ICommandLineOptionsService
+	{
+		public ParserResult<NoteScalerOptions> ParseArguments(IEnumerable<string> args)
+		{
+			return Parser.Default.ParseArguments<NoteScalerOptions>(args);
+		}
+	}
+}

--- a/NoteScaler/Services/ConsoleOutputService.cs
+++ b/NoteScaler/Services/ConsoleOutputService.cs
@@ -1,0 +1,16 @@
+namespace NoteScaler.Services
+{
+	using NoteScaler.Services.Interfaces;
+	using System;
+
+	public sealed class ConsoleOutputService : IConsoleOutputService
+	{
+		public void WriteMessage(string message, ConsoleColor textColor = ConsoleColor.White)
+		{
+			var currentForeground = Console.ForegroundColor;
+			Console.ForegroundColor = textColor;
+			Console.WriteLine(message);
+			Console.ForegroundColor = currentForeground;
+		}
+	}
+}

--- a/NoteScaler/Services/Interfaces/ICommandLineOptionsService.cs
+++ b/NoteScaler/Services/Interfaces/ICommandLineOptionsService.cs
@@ -1,0 +1,11 @@
+﻿namespace NoteScaler.Services.Interfaces
+{
+	using CommandLine;
+	using NoteScaler.Config;
+	using System.Collections.Generic;
+
+	public interface ICommandLineOptionsService
+	{
+		ParserResult<NoteScalerOptions> ParseArguments(IEnumerable<string> args);
+	}
+}

--- a/NoteScaler/Services/Interfaces/IConsoleOutputService.cs
+++ b/NoteScaler/Services/Interfaces/IConsoleOutputService.cs
@@ -1,0 +1,9 @@
+﻿namespace NoteScaler.Services.Interfaces
+{
+	using System;
+
+	public interface IConsoleOutputService
+	{
+		void WriteMessage(string message, ConsoleColor textColor = ConsoleColor.White);
+	}
+}

--- a/NoteScaler/Services/Interfaces/INoteScalerRunner.cs
+++ b/NoteScaler/Services/Interfaces/INoteScalerRunner.cs
@@ -1,0 +1,7 @@
+﻿namespace NoteScaler.Services.Interfaces
+{
+	public interface INoteScalerRunner
+	{
+		int Run(string[] args);
+	}
+}

--- a/NoteScaler/Services/Interfaces/IPlayableSequenceFactory.cs
+++ b/NoteScaler/Services/Interfaces/IPlayableSequenceFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace NoteScaler.Services.Interfaces
+{
+	using NoteScaler.Classes;
+	using NoteScaler.Config;
+
+	public interface IPlayableSequenceFactory
+	{
+		PlayableSequence Create(NoteScalerOptions options, int a4Reference);
+	}
+}

--- a/NoteScaler/Services/Interfaces/IPlayerFactory.cs
+++ b/NoteScaler/Services/Interfaces/IPlayerFactory.cs
@@ -1,0 +1,9 @@
+﻿namespace NoteScaler.Services.Interfaces
+{
+	using NoteScaler.Interfaces;
+
+	public interface IPlayerFactory
+	{
+		IPlayer Create();
+	}
+}

--- a/NoteScaler/Services/Interfaces/IStringInstrumentFactory.cs
+++ b/NoteScaler/Services/Interfaces/IStringInstrumentFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace NoteScaler.Services.Interfaces
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Interfaces;
+
+	public interface IStringInstrumentFactory
+	{
+		IStringInstrument Create(TuningScheme tuningScheme, int numberOfFrets);
+	}
+}

--- a/NoteScaler/Services/NoteScalerRunner.cs
+++ b/NoteScaler/Services/NoteScalerRunner.cs
@@ -1,0 +1,229 @@
+namespace NoteScaler.Services
+{
+	using CommandLine;
+	using NoteScaler.Classes;
+	using NoteScaler.Config;
+	using NoteScaler.Enums;
+	using NoteScaler.Interfaces;
+	using NoteScaler.Models;
+	using NoteScaler.Services.Interfaces;
+	using System;
+	using System.Linq;
+	using System.Threading;
+
+	public sealed class NoteScalerRunner : INoteScalerRunner
+	{
+		private readonly ICommandLineOptionsService commandLineOptionsService;
+		private readonly IPlayableSequenceFactory playableSequenceFactory;
+		private readonly IStringInstrumentFactory stringInstrumentFactory;
+		private readonly IConsoleOutputService consoleOutputService;
+
+		public NoteScalerRunner(
+			ICommandLineOptionsService commandLineOptionsService,
+			IPlayableSequenceFactory playableSequenceFactory,
+			IStringInstrumentFactory stringInstrumentFactory,
+			IConsoleOutputService consoleOutputService)
+		{
+			this.commandLineOptionsService = commandLineOptionsService;
+			this.playableSequenceFactory = playableSequenceFactory;
+			this.stringInstrumentFactory = stringInstrumentFactory;
+			this.consoleOutputService = consoleOutputService;
+		}
+
+		public int Run(string[] args)
+		{
+			commandLineOptionsService.ParseArguments(args)
+				.WithParsed(Run);
+
+			return 0;
+		}
+
+		private void Run(NoteScalerOptions options)
+		{
+			MusicNote.FactoryError += MusicNote_FactoryError;
+			MusicNote.FactoryCreateNote += MusicNote_FactoryCreateNote;
+
+			try
+			{
+				InitializeNoteScalerOptions(options, out var a4Reference, out var key, out var fileName, out var tabName);
+				var playableSequence = playableSequenceFactory.Create(options, a4Reference);
+				playableSequence.PlayableSequenceEvent += PlayableSequence_PlayableSequenceEvent;
+
+				PlayNoteAsRequired(options.Note, a4Reference, playableSequence);
+				PlayTabAsRequired(tabName, playableSequence);
+				PlaySongAsRequired(key, fileName, playableSequence);
+			}
+			finally
+			{
+				MusicNote.FactoryError -= MusicNote_FactoryError;
+				MusicNote.FactoryCreateNote -= MusicNote_FactoryCreateNote;
+			}
+		}
+
+		private void MusicNote_FactoryCreateNote(object sender, EventArgs e)
+		{
+			if (sender is MusicNote musicNote)
+			{
+				consoleOutputService.WriteMessage($"Created: {musicNote.Key}{musicNote.DesiredOctave}", ConsoleColor.Green);
+			}
+		}
+
+		private void MusicNote_FactoryError(object sender, Exception e)
+		{
+			consoleOutputService.WriteMessage($"{e}", ConsoleColor.Red);
+		}
+
+		private void PlayableSequence_PlayableSequenceEvent(object sender, PlayableSequenceEvent e)
+		{
+			var textColor = ConsoleColor.White;
+			switch (e.EventType)
+			{
+				case PlayableEventType.StartSequence:
+				case PlayableEventType.CreateNote:
+					textColor = ConsoleColor.Blue;
+					break;
+				case PlayableEventType.SettingSequence:
+				case PlayableEventType.StopSequence:
+					textColor = ConsoleColor.Yellow;
+					break;
+				case PlayableEventType.PlayingNote:
+					textColor = ConsoleColor.Green;
+					break;
+				case PlayableEventType.Error:
+					textColor = ConsoleColor.Red;
+					break;
+				case PlayableEventType.SequenceLoaded:
+					textColor = ConsoleColor.White;
+					break;
+			}
+			consoleOutputService.WriteMessage($"Event: {e.EventType} -> {e.EventDetails}", textColor);
+		}
+
+		private void InitializeNoteScalerOptions(NoteScalerOptions options, out int a4Reference, out string key, out string fileName, out string tabName)
+		{
+			key = options.Key;
+			fileName = options.File;
+			tabName = options.Tab;
+			var pause = options.Speed.GetValueOrDefault() * options.PreWait.GetValueOrDefault();
+			a4Reference = options.Range.GetValueOrDefault();
+			if (pause > 0)
+			{
+				consoleOutputService.WriteMessage($"Pausing {pause}ms prior to playing...");
+				Thread.Sleep(pause);
+			}
+		}
+
+		private void PlayNoteAsRequired(string note, int a4Reference, PlayableSequence playableSequence)
+		{
+			if (note != null)
+			{
+				var musicNote = MusicNote.Create(note, a4Reference);
+				if (musicNote?.IsValid ?? false)
+				{
+					ShowNote(musicNote);
+					var musicNotes = musicNote.MajorScale.ToArray();
+					consoleOutputService.WriteMessage($"Playing Major Scale: {string.Join(',', musicNotes)}");
+					playableSequence.LoadSequenceFromString(musicNote.MajorScale);
+					playableSequence.Prepare();
+					playableSequence.Play();
+					Thread.Sleep(1000);
+					musicNotes = musicNote.MinorScale.ToArray();
+					consoleOutputService.WriteMessage($"Playing Minor Scale: {string.Join(',', musicNotes)}");
+					playableSequence.LoadSequenceFromString(musicNote.MinorScale);
+					playableSequence.Prepare();
+					playableSequence.Play();
+					Thread.Sleep(1000);
+					consoleOutputService.WriteMessage($"Playing Relative Minor Scale {musicNote.RelativeMinor}m: {string.Join(',', musicNote.RelativeMinorScale)}");
+					playableSequence.LoadSequenceFromString(musicNote.RelativeMinorScale);
+					playableSequence.Prepare();
+					playableSequence.Play();
+				}
+				else
+				{
+					consoleOutputService.WriteMessage($"{note} is NOT a valid note!", ConsoleColor.Red);
+				}
+			}
+		}
+
+		private void PlaySongAsRequired(string key, string fileName, PlayableSequence playableSequence)
+		{
+			if (!string.IsNullOrEmpty(fileName))
+			{
+				var result = playableSequence.LoadFromFile(fileName, "Songs", out var errorString, out Song song);
+				if (!result)
+				{
+					consoleOutputService.WriteMessage(errorString, ConsoleColor.Red);
+				}
+				else
+				{
+					var currentSong = GetTheSongByKeyAsRequired(key, song);
+					playableSequence.ConvertSongNotesToNoteSequence(currentSong);
+					playableSequence.Prepare();
+					playableSequence.Play();
+
+					if (song.Reverse)
+					{
+						playableSequence.ReverseSequence();
+						playableSequence.Play();
+					}
+				}
+			}
+		}
+
+		private void PlayTabAsRequired(string tabName, PlayableSequence playableSequence)
+		{
+			if (!string.IsNullOrEmpty(tabName))
+			{
+				var result = playableSequence.LoadFromFile(tabName, "Tabs", out var errorString, out Tablature tabs);
+				if (!result)
+				{
+					consoleOutputService.WriteMessage(errorString, ConsoleColor.Red);
+				}
+				else
+				{
+					tabs.FixUp();
+					var guitar = stringInstrumentFactory.Create(tabs.Tuning, 21);
+					playableSequence.ConvertTabsToNoteSequence(guitar, tabs);
+					playableSequence.Repeat = tabs.Repeat;
+					playableSequence.Prepare();
+					playableSequence.Play();
+				}
+			}
+		}
+
+		private SongKey GetTheSongByKeyAsRequired(string key, Song song)
+		{
+			var currentSong = (SongKey)song;
+			if (!string.IsNullOrEmpty(key) && song.Keys.Any(songKey => songKey?.Name?.Equals(key) ?? false))
+			{
+				currentSong = song.Keys.SingleOrDefault(songKey => songKey?.Name?.Equals(key, StringComparison.InvariantCultureIgnoreCase) ?? false);
+			}
+			else
+			{
+				if (!string.IsNullOrEmpty(song.Name) && song.Keys != null)
+				{
+					currentSong = song.Keys.SingleOrDefault(songKey => songKey?.Name?.Equals(song.Name, StringComparison.InvariantCultureIgnoreCase) ?? false);
+				}
+			}
+
+			return currentSong;
+		}
+
+		private void ShowNote(MusicNote musicNote)
+		{
+			var relativeMinor = musicNote.RelativeMinor;
+			var relativeMajor = musicNote.RelativeMajor;
+			consoleOutputService.WriteMessage($"{musicNote} is the current note");
+			consoleOutputService.WriteMessage($"Frequencies for this note are: {string.Join(',', musicNote.Frequencies.Select(f => f.ToString()))}");
+			consoleOutputService.WriteMessage($"Of the 12 natural, flat and sharp notes {musicNote} has {musicNote.NoteBefore} before it and {musicNote.NoteAfter} after it.");
+			consoleOutputService.WriteMessage($"Of the 7 notes in the {musicNote} scale {musicNote} has {musicNote.MajorNoteBefore} before it and {musicNote.MajorNoteAfter} after it.");
+			consoleOutputService.WriteMessage($"Of the 7 notes in the {musicNote}m scale {musicNote} has {musicNote.MinorNoteBefore} before it and {musicNote.MinorNoteAfter} after it.");
+			consoleOutputService.WriteMessage($"Notes in {musicNote} are: {string.Join(',', musicNote.MajorScale)}");
+			consoleOutputService.WriteMessage($"Notes in {musicNote}m are: {string.Join(',', musicNote.MinorScale)}");
+			consoleOutputService.WriteMessage($"Major Chord: {string.Join(',', musicNote.MajorChord15)} minor Chord: {string.Join(',', musicNote.MinorChord15)}");
+			consoleOutputService.WriteMessage($"The relative minor is {relativeMinor}m");
+			consoleOutputService.WriteMessage($"The relative minor scale is {string.Join(',', musicNote.RelativeMinorScale)}");
+			consoleOutputService.WriteMessage($"The relative Major to the minor is {relativeMajor}");
+		}
+	}
+}

--- a/NoteScaler/Services/PlayableSequenceFactory.cs
+++ b/NoteScaler/Services/PlayableSequenceFactory.cs
@@ -1,0 +1,32 @@
+namespace NoteScaler.Services
+{
+	using NoteScaler.Classes;
+	using NoteScaler.Config;
+	using NoteScaler.Enums;
+	using NoteScaler.Services.Interfaces;
+
+	public sealed class PlayableSequenceFactory : IPlayableSequenceFactory
+	{
+		private readonly IPlayerFactory playerFactory;
+		private readonly IStringInstrumentFactory stringInstrumentFactory;
+
+		public PlayableSequenceFactory(IPlayerFactory playerFactory, IStringInstrumentFactory stringInstrumentFactory)
+		{
+			this.playerFactory = playerFactory;
+			this.stringInstrumentFactory = stringInstrumentFactory;
+		}
+
+		public PlayableSequence Create(NoteScalerOptions options, int a4Reference)
+		{
+			return new PlayableSequence(
+				playerFactory.Create,
+				() => stringInstrumentFactory.Create(TuningScheme.Standard, 24))
+			{
+				MeasureTime = options.Speed.GetValueOrDefault(),
+				Octave = options.Octave.GetValueOrDefault(),
+				A4Reference = a4Reference,
+				InstrumentType = options.Instrument
+			};
+		}
+	}
+}

--- a/NoteScaler/Services/SignalNotePlayerFactory.cs
+++ b/NoteScaler/Services/SignalNotePlayerFactory.cs
@@ -1,0 +1,14 @@
+namespace NoteScaler.Services
+{
+	using NoteScaler.Classes;
+	using NoteScaler.Interfaces;
+	using NoteScaler.Services.Interfaces;
+
+	public sealed class SignalNotePlayerFactory : IPlayerFactory
+	{
+		public IPlayer Create()
+		{
+			return new SignalNotePlayer();
+		}
+	}
+}

--- a/NoteScaler/Services/StringInstrumentFactory.cs
+++ b/NoteScaler/Services/StringInstrumentFactory.cs
@@ -1,0 +1,15 @@
+namespace NoteScaler.Services
+{
+	using NoteScaler.Classes;
+	using NoteScaler.Enums;
+	using NoteScaler.Interfaces;
+	using NoteScaler.Services.Interfaces;
+
+	public sealed class StringInstrumentFactory : IStringInstrumentFactory
+	{
+		public IStringInstrument Create(TuningScheme tuningScheme, int numberOfFrets)
+		{
+			return new Guitar(tuningScheme, numberOfFrets);
+		}
+	}
+}

--- a/NoteScalerTests/Services/ServiceFactoryTests.cs
+++ b/NoteScalerTests/Services/ServiceFactoryTests.cs
@@ -1,0 +1,53 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Classes;
+	using NoteScaler.Config;
+	using NoteScaler.Enums;
+	using NoteScaler.Services;
+	using System.Linq;
+	using Xunit;
+
+	public class ServiceFactoryTests
+	{
+		[Fact]
+		public void CommandLineOptionsService_PreservesExistingCommandLineParsing()
+		{
+			var service = new CommandLineOptionsService();
+			var parsedOptions = service.ParseArguments(new[] { "--note", "C" });
+
+			parsedOptions.WithParsed(options => Assert.Equal("C", options.Note));
+		}
+
+		[Fact]
+		public void PlayableSequenceFactory_CreatesConfiguredPlayableSequence()
+		{
+			var factory = new PlayableSequenceFactory(new SignalNotePlayerFactory(), new StringInstrumentFactory());
+			var options = new NoteScalerOptions
+			{
+				Speed = 300,
+				Octave = 3,
+				Instrument = InstrumentType.Horn
+			};
+
+			var playableSequence = factory.Create(options, 440);
+
+			Assert.Equal(300, playableSequence.MeasureTime);
+			Assert.Equal(3, playableSequence.Octave);
+			Assert.Equal(440, playableSequence.A4Reference);
+			Assert.Equal(InstrumentType.Horn, playableSequence.InstrumentType);
+		}
+
+		[Fact]
+		public void StringInstrumentFactory_CreatesGuitarWithRequestedTuningAndFrets()
+		{
+			var factory = new StringInstrumentFactory();
+
+			var instrument = factory.Create(TuningScheme.DropD, 21);
+
+			var guitar = Assert.IsType<Guitar>(instrument);
+			Assert.Equal(TuningScheme.DropD, guitar.TuningScheme);
+			Assert.Equal(21, guitar.Frets);
+			Assert.Equal(6, guitar.Strings.Count());
+		}
+	}
+}

--- a/NoteScalerTests/Services/ServiceFactoryTests.cs
+++ b/NoteScalerTests/Services/ServiceFactoryTests.cs
@@ -13,9 +13,10 @@ namespace NoteScalerTests.Services
 		public void CommandLineOptionsService_PreservesExistingCommandLineParsing()
 		{
 			var service = new CommandLineOptionsService();
+
 			var parsedOptions = service.ParseArguments(new[] { "--note", "C" });
 
-			parsedOptions.WithParsed(options => Assert.Equal("C", options.Note));
+			Assert.Equal("Parsed", parsedOptions.Tag.ToString());
 		}
 
 		[Fact]


### PR DESCRIPTION
## Summary
- addresses #12 dependency cleanup and architecture modernization
- removes the unnecessary `System.Collections` package reference
- updates `Newtonsoft.Json`, `CommandLineParser`, and `NAudio`
- adds `Microsoft.Extensions.DependencyInjection`
- refactors `Program.cs` into a DI composition root matching the DCSMissionInspector pattern
- moves command execution into `NoteScalerRunner`
- adds service/interface boundaries for command-line parsing, console output, player creation, string-instrument creation, and playable-sequence creation
- keeps existing `CommandLineParser`-based argument processing
- adds service/factory regression tests

## Architecture Notes
- `Program.Main` now builds the service provider, resolves `INoteScalerRunner`, and delegates execution.
- Existing domain/model classes are preserved.
- `PlayableSequence` keeps its default constructor for compatibility, while also supporting injected player/instrument factories.

## Validation
- CI will run through the shared reusable workflow after PR creation.

## Notes
- Draft PR only.
- No merge to `master`.