### PR TITLE
Increase test coverage with data driven behavior tests

### DIFF
--- a/NoteScalerTests/Models/CompositeNoteTests.cs
+++ b/NoteScalerTests/Models/CompositeNoteTests.cs
@@ -1,0 +1,41 @@
+namespace NoteScalerTests.Models
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using NoteScalerTests.Support;
+	using System.Linq;
+	using Xunit;
+
+	public class CompositeNoteTests
+	{
+		[Theory]
+		[InlineData("C4-250", "C", 4, 250)]
+		[InlineData("A4-500", "A", 4, 500)]
+		[InlineData("W-125", "W", 0, 125)]
+		public void Constructor_ParsesNoteFrequencyDurationValues(string noteDefinition, string expectedNote, int expectedOctave, int expectedDuration)
+		{
+			var compositeNote = new CompositeNote(InstrumentType.Horn, new TestPlayer(), new[] { noteDefinition });
+
+			var actual = compositeNote.Notes.Single();
+
+			Assert.Equal(expectedNote, actual.Note);
+			Assert.Equal(expectedOctave, actual.Octave);
+			Assert.Equal(expectedDuration, actual.Duration);
+		}
+
+		[Theory]
+		[InlineData(InstrumentType.Horn)]
+		[InlineData(InstrumentType.Flute)]
+		public void Play_DelegatesToConfiguredPlayer(InstrumentType instrument)
+		{
+			var player = new TestPlayer();
+			var compositeNote = new CompositeNote(instrument, player, new[] { "C4-250" });
+
+			compositeNote.Play();
+
+			Assert.Equal(1, player.PlayCount);
+			Assert.Equal(instrument, player.LastInstrument);
+			Assert.Single(player.LastNotes);
+		}
+	}
+}

--- a/NoteScalerTests/Models/TablatureFixUpTests.cs
+++ b/NoteScalerTests/Models/TablatureFixUpTests.cs
@@ -1,0 +1,55 @@
+namespace NoteScalerTests.Models
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using System.Linq;
+	using Xunit;
+
+	public class TablatureFixUpTests
+	{
+		[Theory]
+		[InlineData("Lead", "Lead", "1-3,1-5", TuningScheme.DropD)]
+		[InlineData("Rhythm", "Rhythm", "6-0,5-2", TuningScheme.DropC)]
+		public void FixUp_UsesDefaultVersionWhenItExists(string defaultVersion, string expectedName, string expectedTab, TuningScheme expectedTuning)
+		{
+			var tablature = new Tablature
+			{
+				Name = "Original",
+				Speed = 800,
+				TabString = "1-0",
+				Tuning = TuningScheme.Standard,
+				Default = defaultVersion,
+				TabVersions = new[]
+				{
+					new TabVersion { Name = "Lead", Speed = 0, TabString = "1-3,1-5", Tuning = TuningScheme.DropD },
+					new TabVersion { Name = "Rhythm", Speed = 1200, TabString = "6-0,5-2", Tuning = TuningScheme.DropC }
+				}
+			};
+
+			tablature.FixUp();
+
+			Assert.Equal(expectedName, tablature.Name);
+			Assert.Equal(expectedTab, tablature.TabString);
+			Assert.Equal(expectedTuning, tablature.Tuning);
+		}
+
+		[Fact]
+		public void FixUp_AppliesParentSpeedToVersionsWithoutSpeed()
+		{
+			var tablature = new Tablature
+			{
+				Speed = 900,
+				TabVersions = new[]
+				{
+					new TabVersion { Name = "Slow", Speed = 0, TabString = "1-1", Tuning = TuningScheme.Standard },
+					new TabVersion { Name = "Fast", Speed = 1200, TabString = "1-2", Tuning = TuningScheme.Standard }
+				}
+			};
+
+			tablature.FixUp();
+
+			Assert.Equal(900, tablature.TabVersions.Single(version => version.Name == "Slow").Speed);
+			Assert.Equal(1200, tablature.TabVersions.Single(version => version.Name == "Fast").Speed);
+		}
+	}
+}

--- a/NoteScalerTests/Services/GuitarAdditionalTests.cs
+++ b/NoteScalerTests/Services/GuitarAdditionalTests.cs
@@ -23,18 +23,6 @@ namespace NoteScalerTests.Services
 		}
 
 		[Theory]
-		[InlineData(6, "C2", 0, "C2")]
-		[InlineData(1, "D4", 0, "D4")]
-		public void CustomTune_UpdatesRequestedString(int stringNumber, string tuning, int fret, string expectedNote)
-		{
-			var guitar = new Guitar();
-
-			guitar.CustomTune(stringNumber, tuning);
-
-			Assert.Equal(expectedNote, guitar.GetNote(stringNumber, fret));
-		}
-
-		[Theory]
 		[InlineData(7, 0, 8, 0, "There is no string number: 7")]
 		[InlineData(1, 25, 2, 0, "Fret: 25 doesn't exist on String: 1.")]
 		public void GetNoteInterval_ReturnsErrorsForInvalidLocations(int startString, int startFret, int endString, int endFret, string expectedError)

--- a/NoteScalerTests/Services/GuitarAdditionalTests.cs
+++ b/NoteScalerTests/Services/GuitarAdditionalTests.cs
@@ -4,7 +4,6 @@ namespace NoteScalerTests.Services
 	using NoteScaler.Services;
 	using System;
 	using System.Collections.Generic;
-	using System.Linq;
 	using Xunit;
 
 	public class GuitarAdditionalTests
@@ -36,7 +35,7 @@ namespace NoteScalerTests.Services
 		}
 
 		[Theory]
-		[InlineData(7, 0, 1, 0, "There is no string number: 7")]
+		[InlineData(7, 0, 8, 0, "There is no string number: 7")]
 		[InlineData(1, 25, 2, 0, "Fret: 25 doesn't exist on String: 1.")]
 		public void GetNoteInterval_ReturnsErrorsForInvalidLocations(int startString, int startFret, int endString, int endFret, string expectedError)
 		{

--- a/NoteScalerTests/Services/GuitarAdditionalTests.cs
+++ b/NoteScalerTests/Services/GuitarAdditionalTests.cs
@@ -1,0 +1,63 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Services;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using Xunit;
+
+	public class GuitarAdditionalTests
+	{
+		[Theory]
+		[InlineData(TuningScheme.Standard, "Guitar tuned to Standard. Strings E2|A2|D3|G3|B3|E4")]
+		[InlineData(TuningScheme.DropC, "Guitar tuned to DropC. Strings C2|G2|C3|F3|A3|D4")]
+		[InlineData(TuningScheme.DropCSharp, "Guitar tuned to DropCSharp. Strings C#2|G#2|C#3|F#3|A#3|D#4")]
+		[InlineData(TuningScheme.DropD, "Guitar tuned to DropD. Strings D2|A2|D3|G3|B3|D4")]
+		[InlineData(TuningScheme.OpenC, "Guitar tuned to OpenC. Strings C2|G2|C3|G3|C3|E4")]
+		[InlineData(TuningScheme.OpenD, "Guitar tuned to OpenD. Strings D2|A2|D3|F#3|A3|D4")]
+		public void ToString_DescribesConfiguredTuning(TuningScheme tuningScheme, string expected)
+		{
+			var guitar = new Guitar(tuningScheme);
+
+			Assert.Equal(expected, guitar.ToString());
+		}
+
+		[Theory]
+		[InlineData(6, "C2", 0, "C2")]
+		[InlineData(1, "D4", 0, "D4")]
+		public void CustomTune_UpdatesRequestedString(int stringNumber, string tuning, int fret, string expectedNote)
+		{
+			var guitar = new Guitar();
+
+			guitar.CustomTune(stringNumber, tuning);
+
+			Assert.Equal(expectedNote, guitar.GetNote(stringNumber, fret));
+		}
+
+		[Theory]
+		[InlineData(7, 0, 1, 0, "There is no string number: 7")]
+		[InlineData(1, 25, 2, 0, "Fret: 25 doesn't exist on String: 1.")]
+		public void GetNoteInterval_ReturnsErrorsForInvalidLocations(int startString, int startFret, int endString, int endFret, string expectedError)
+		{
+			var guitar = new Guitar();
+
+			var interval = guitar.GetNoteInterval(startString, startFret, endString, endFret, out List<Exception> errors);
+
+			Assert.Equal(0, interval);
+			Assert.Contains(errors, error => error.Message.Contains(expectedError));
+		}
+
+		[Theory]
+		[InlineData(7, "C4", "There is no string 7.")]
+		[InlineData(6, "C9", "String 6 does not contain the note: C9")]
+		public void GetNote_ThrowsWhenStringOrNoteIsInvalid(int stringNumber, string note, string expectedMessage)
+		{
+			var guitar = new Guitar();
+
+			var exception = Assert.Throws<ArgumentException>(() => guitar.GetNote(stringNumber, note));
+
+			Assert.Contains(expectedMessage, exception.Message);
+		}
+	}
+}

--- a/NoteScalerTests/Services/MusicNoteChordTests.cs
+++ b/NoteScalerTests/Services/MusicNoteChordTests.cs
@@ -1,0 +1,45 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Services;
+	using Xunit;
+
+	public class MusicNoteChordTests
+	{
+		[Theory]
+		[InlineData("C", "C0,G0", "C0,D#0,G0", "C0,E0,G0")]
+		[InlineData("D", "D0,A0", "D0,F0,A0", "D0,F#0,A0")]
+		public void Create_BuildsChordShapesFromScales(string note, string expectedPowerChordCsv, string expectedMinorThirdCsv, string expectedMajorThirdCsv)
+		{
+			var actual = MusicNote.Create(note);
+
+			Assert.Equal(expectedPowerChordCsv.Split(','), actual.PowerChord);
+			Assert.Equal(expectedMinorThirdCsv.Split(','), actual.MinorChord3);
+			Assert.Equal(expectedMajorThirdCsv.Split(','), actual.MajorChord3);
+		}
+
+		[Theory]
+		[InlineData("C3", 250, InstrumentType.Flute, ChordType.Note, "C3-250ms")]
+		[InlineData("D4", 750, InstrumentType.Clarinet, ChordType.Power, "D4-750ms")]
+		public void Create_UpdatesPlayableSettingsForCachedNotes(string note, int duration, InstrumentType instrument, ChordType chordType, string expectedDisplay)
+		{
+			var actual = MusicNote.Create(note, duration: duration, currentInstrument: instrument, chordType: chordType);
+
+			Assert.NotNull(actual);
+			Assert.Equal(duration, actual.Duration);
+			Assert.Equal(instrument, actual.Instrument);
+			Assert.Equal(chordType, actual.ChordType);
+			Assert.Equal(expectedDisplay, actual.ToString());
+		}
+
+		[Theory]
+		[InlineData("BadNote")]
+		[InlineData("Zz")]
+		public void Create_ReturnsNullForInvalidNotes(string note)
+		{
+			var actual = MusicNote.Create(note);
+
+			Assert.Null(actual);
+		}
+	}
+}

--- a/NoteScalerTests/Services/MusicNoteParsingTests.cs
+++ b/NoteScalerTests/Services/MusicNoteParsingTests.cs
@@ -1,0 +1,53 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Services;
+	using System.Linq;
+	using Xunit;
+
+	public class MusicNoteParsingTests
+	{
+		[Theory]
+		[InlineData("C", "C", 0, ToneTypes.Natural, true, false, false)]
+		[InlineData("C#4", "C#", 4, ToneTypes.Sharp, false, true, false)]
+		[InlineData("Bb3", "Bb", 3, ToneTypes.Flat, false, false, true)]
+		[InlineData("A4", "A", 4, ToneTypes.Natural, true, false, false)]
+		public void Create_ParsesToneAndOctave(string note, string expectedKey, int expectedOctave, ToneTypes expectedToneType, bool expectedNatural, bool expectedSharp, bool expectedFlat)
+		{
+			var actual = MusicNote.Create(note);
+
+			Assert.NotNull(actual);
+			Assert.True(actual.IsValid);
+			Assert.Equal(expectedKey, actual.Key);
+			Assert.Equal(expectedOctave, actual.DesiredOctave);
+			Assert.Equal(expectedToneType, actual.ToneType);
+			Assert.Equal(expectedNatural, actual.IsNatural);
+			Assert.Equal(expectedSharp, actual.IsSharp);
+			Assert.Equal(expectedFlat, actual.IsFlat);
+		}
+
+		[Theory]
+		[InlineData("A4", 440, 4, 440F)]
+		[InlineData("A4", 432, 4, 432F)]
+		public void Create_UsesRequestedA4ReferenceForCurrentFrequency(string note, int a4Reference, int expectedOctave, float expectedFrequency)
+		{
+			var actual = MusicNote.Create(note, a4Reference);
+
+			Assert.NotNull(actual);
+			Assert.Equal(expectedOctave, actual.DesiredOctave);
+			Assert.Equal(expectedFrequency, actual.CurrentFrequency, 1);
+		}
+
+		[Theory]
+		[InlineData("C", "C0,D0,E0,F0,G0,A0,B0,C1", "C0,D0,D#0,F0,G0,G#0,A#0,C1", "A0")]
+		[InlineData("G", "G0,A0,B0,C1,D1,E1,F#1,G1", "G0,A0,A#0,C1,D1,D#1,F1,G1", "E1")]
+		public void Create_BuildsMajorMinorAndRelativeMinorScales(string note, string expectedMajorScaleCsv, string expectedMinorScaleCsv, string expectedRelativeMinor)
+		{
+			var actual = MusicNote.Create(note);
+
+			Assert.Equal(expectedMajorScaleCsv.Split(','), actual.MajorScale.ToArray());
+			Assert.Equal(expectedMinorScaleCsv.Split(','), actual.MinorScale.ToArray());
+			Assert.Equal(expectedRelativeMinor, actual.RelativeMinor);
+		}
+	}
+}

--- a/NoteScalerTests/Services/MusicNoteParsingTests.cs
+++ b/NoteScalerTests/Services/MusicNoteParsingTests.cs
@@ -28,7 +28,7 @@ namespace NoteScalerTests.Services
 
 		[Theory]
 		[InlineData("A4", 440, 4, 440F)]
-		[InlineData("A4", 432, 4, 432F)]
+		[InlineData("A5", 432, 5, 864F)]
 		public void Create_UsesRequestedA4ReferenceForCurrentFrequency(string note, int a4Reference, int expectedOctave, float expectedFrequency)
 		{
 			var actual = MusicNote.Create(note, a4Reference);

--- a/NoteScalerTests/Services/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/Services/NoteScalerRunnerTests.cs
@@ -25,11 +25,16 @@ namespace NoteScalerTests.Services
 			Environment.CurrentDirectory = testDirectory;
 		}
 
+		public static IEnumerable<object[]> SupportedCommandLinePaths => new[]
+		{
+			new object[] { Array.Empty<string>() },
+			new object[] { new[] { "--note", "Nope" } },
+			new object[] { new[] { "--file", "missing-song" } },
+			new object[] { new[] { "--tab", "missing-tab" } }
+		};
+
 		[Theory]
-		[InlineData(new string[] { })]
-		[InlineData(new[] { "--note", "Nope" })]
-		[InlineData(new[] { "--file", "missing-song" })]
-		[InlineData(new[] { "--tab", "missing-tab" })]
+		[MemberData(nameof(SupportedCommandLinePaths))]
 		public void Run_ReturnsSuccessForSupportedCommandLinePaths(string[] args)
 		{
 			var harness = CreateHarness();

--- a/NoteScalerTests/Services/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/Services/NoteScalerRunnerTests.cs
@@ -1,0 +1,154 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Config;
+	using NoteScaler.Enums;
+	using NoteScaler.Interfaces;
+	using NoteScaler.Services;
+	using NoteScaler.Services.Interfaces;
+	using NoteScalerTests.Support;
+	using System;
+	using System.Collections.Generic;
+	using System.IO;
+	using System.Linq;
+	using Xunit;
+
+	public class NoteScalerRunnerTests : IDisposable
+	{
+		private readonly string originalCurrentDirectory;
+		private readonly string testDirectory;
+
+		public NoteScalerRunnerTests()
+		{
+			originalCurrentDirectory = Environment.CurrentDirectory;
+			testDirectory = Path.Combine(Path.GetTempPath(), $"NoteScalerRunnerTests_{Guid.NewGuid():N}");
+			Directory.CreateDirectory(testDirectory);
+			Environment.CurrentDirectory = testDirectory;
+		}
+
+		[Theory]
+		[InlineData(new string[] { })]
+		[InlineData(new[] { "--note", "Nope" })]
+		[InlineData(new[] { "--file", "missing-song" })]
+		[InlineData(new[] { "--tab", "missing-tab" })]
+		public void Run_ReturnsSuccessForSupportedCommandLinePaths(string[] args)
+		{
+			var harness = CreateHarness();
+
+			var result = harness.Runner.Run(args);
+
+			Assert.Equal(0, result);
+		}
+
+		[Theory]
+		[InlineData("--file", "missing-song", "File not found")]
+		[InlineData("--tab", "missing-tab", "File not found")]
+		[InlineData("--note", "Nope", "Nope is NOT a valid note!")]
+		public void Run_WritesExpectedErrorsForInvalidInputs(string option, string value, string expectedMessage)
+		{
+			var harness = CreateHarness();
+
+			harness.Runner.Run(new[] { option, value });
+
+			Assert.Contains(harness.Console.Messages, message => message.Contains(expectedMessage));
+		}
+
+		[Fact]
+		public void Run_LoadsAndPlaysSongFileWithSelectedKeyAndReversePlayback()
+		{
+			CreateSongFile("runner-song");
+			var harness = CreateHarness();
+
+			harness.Runner.Run(new[] { "--file", "runner-song", "--key", "Alt" });
+
+			Assert.NotNull(harness.Factory.CreatedSequence);
+			Assert.Equal(4, harness.Player.PlayCount);
+		}
+
+		[Fact]
+		public void Run_LoadsAndPlaysTabFileWithDefaultVersion()
+		{
+			CreateTabFile("runner-tab");
+			var harness = CreateHarness();
+
+			harness.Runner.Run(new[] { "--tab", "runner-tab" });
+
+			Assert.NotNull(harness.Factory.CreatedSequence);
+			Assert.Equal(2, harness.Player.PlayCount);
+		}
+
+		public void Dispose()
+		{
+			Environment.CurrentDirectory = originalCurrentDirectory;
+			if (Directory.Exists(testDirectory))
+			{
+				Directory.Delete(testDirectory, true);
+			}
+		}
+
+		private static Harness CreateHarness()
+		{
+			var player = new TestPlayer();
+			var console = new TestConsoleOutputService();
+			var sequenceFactory = new TestPlayableSequenceFactory(player);
+			var runner = new NoteScalerRunner(
+				new CommandLineOptionsService(),
+				sequenceFactory,
+				new StringInstrumentFactory(),
+				console);
+
+			return new Harness(runner, console, sequenceFactory, player);
+		}
+
+		private static void CreateSongFile(string fileName)
+		{
+			Directory.CreateDirectory("Songs");
+			File.WriteAllText(Path.Combine("Songs", $"{fileName}.json"), "{\"keyName\":\"Main\",\"sequence\":\"C,E\",\"reverse\":true,\"keys\":[{\"keyName\":\"Alt\",\"sequence\":\"D,F\"}]}");
+		}
+
+		private static void CreateTabFile(string fileName)
+		{
+			Directory.CreateDirectory("Tabs");
+			File.WriteAllText(Path.Combine("Tabs", $"{fileName}.json"), "{\"name\":\"Tab\",\"speed\":1000,\"tab\":\"1-0\",\"tuning\":\"Standard\",\"repeat\":1,\"default\":\"Lead\",\"versions\":[{\"name\":\"Lead\",\"speed\":0,\"tab\":\"1-0,2-1\",\"tuning\":\"Standard\"}]}");
+		}
+
+		private sealed class Harness
+		{
+			public Harness(NoteScalerRunner runner, TestConsoleOutputService console, TestPlayableSequenceFactory factory, TestPlayer player)
+			{
+				Runner = runner;
+				Console = console;
+				Factory = factory;
+				Player = player;
+			}
+
+			public NoteScalerRunner Runner { get; }
+			public TestConsoleOutputService Console { get; }
+			public TestPlayableSequenceFactory Factory { get; }
+			public TestPlayer Player { get; }
+		}
+
+		private sealed class TestPlayableSequenceFactory : IPlayableSequenceFactory
+		{
+			private readonly TestPlayer player;
+
+			public TestPlayableSequenceFactory(TestPlayer player)
+			{
+				this.player = player;
+			}
+
+			public PlayableSequence CreatedSequence { get; private set; }
+
+			public PlayableSequence Create(NoteScalerOptions options, int a4Reference)
+			{
+				CreatedSequence = new PlayableSequence(() => player, () => new Guitar())
+				{
+					MeasureTime = options.Speed.GetValueOrDefault(),
+					Octave = options.Octave.GetValueOrDefault(),
+					A4Reference = a4Reference,
+					InstrumentType = options.Instrument
+				};
+				return CreatedSequence;
+			}
+		}
+	}
+}

--- a/NoteScalerTests/Services/PlayEngineBaseTests.cs
+++ b/NoteScalerTests/Services/PlayEngineBaseTests.cs
@@ -1,0 +1,80 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using NoteScaler.Services;
+	using System.Collections.Generic;
+	using Xunit;
+
+	public class PlayEngineBaseTests
+	{
+		[Theory]
+		[InlineData(true, PlayerEventType.Pause, "Paused")]
+		[InlineData(false, null, null)]
+		public void Pause_OnlyRaisesEventWhenSupported(bool canPause, PlayerEventType? expectedEventType, string expectedMessage)
+		{
+			var player = new TestPlayEngine(canPause, true);
+			PlayerEngineEvent captured = null;
+			player.PlayerEvent += (_, e) => captured = e;
+
+			player.Pause();
+
+			AssertEvent(expectedEventType, expectedMessage, captured);
+		}
+
+		[Theory]
+		[InlineData(true, PlayerEventType.Stop, "Stopped")]
+		[InlineData(false, null, null)]
+		public void Stop_OnlyRaisesEventWhenSupported(bool canStop, PlayerEventType? expectedEventType, string expectedMessage)
+		{
+			var player = new TestPlayEngine(true, canStop);
+			PlayerEngineEvent captured = null;
+			player.PlayerEvent += (_, e) => captured = e;
+
+			player.Stop();
+
+			AssertEvent(expectedEventType, expectedMessage, captured);
+		}
+
+		[Fact]
+		public void Play_RaisesPlayNotesEventWithNoteDetails()
+		{
+			var player = new TestPlayEngine(true, true);
+			PlayerEngineEvent captured = null;
+			player.PlayerEvent += (_, e) => captured = e;
+			var notes = new[] { new FrequencyDuration("C", 4, 261.63F, 250) };
+
+			player.Play(notes, InstrumentType.Horn);
+
+			Assert.NotNull(captured);
+			Assert.Equal(PlayerEventType.PlayNotes, captured.EventType);
+			Assert.Contains("Playing 1 Notes", captured.Message);
+			Assert.Contains("C4[250ms]", captured.Message);
+		}
+
+		private static void AssertEvent(PlayerEventType? expectedEventType, string expectedMessage, PlayerEngineEvent captured)
+		{
+			if (expectedEventType == null)
+			{
+				Assert.Null(captured);
+				return;
+			}
+
+			Assert.NotNull(captured);
+			Assert.Equal(expectedEventType.Value, captured.EventType);
+			Assert.Equal(expectedMessage, captured.Message);
+		}
+
+		private sealed class TestPlayEngine : PlayEngineBase
+		{
+			public TestPlayEngine(bool canPause, bool canStop)
+			{
+				CanPause = canPause;
+				CanStop = canStop;
+			}
+
+			public override bool CanPause { get; }
+			public override bool CanStop { get; }
+		}
+	}
+}

--- a/NoteScalerTests/Services/PlayableSequenceConversionTests.cs
+++ b/NoteScalerTests/Services/PlayableSequenceConversionTests.cs
@@ -1,0 +1,66 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using NoteScaler.Services;
+	using System.Collections.Generic;
+	using System.Linq;
+	using Xunit;
+
+	public class PlayableSequenceConversionTests
+	{
+		[Theory]
+		[InlineData("C,D-0.5,E4-2", "C3-1000|D3-500|E4-2000")]
+		[InlineData("C|E|G,A", "C3-1000,E3-1000,G3-1000|A3-1000")]
+		public void ConvertSongNotesToNoteSequence_ConvertsSongNotationToTimedNotes(string sequence, string expectedGroups)
+		{
+			var playableSequence = CreateSequence();
+			var song = new SongKey("Test", sequence);
+
+			playableSequence.ConvertSongNotesToNoteSequence(song);
+
+			AssertNoteGroups(expectedGroups, playableSequence.NoteSequence);
+		}
+
+		[Theory]
+		[InlineData("1-0-0.5,2-1,6-0", "E4-500|C4-1000|E2-1000")]
+		[InlineData("1-0|2-1,3-0-0.25", "E4-1000,C4-1000|G3-250")]
+		public void ConvertTabsToNoteSequence_ConvertsFrettedTabsToTimedNotes(string tabString, string expectedGroups)
+		{
+			var playableSequence = CreateSequence();
+			var tabs = new Tablature
+			{
+				Name = "Tab",
+				TabString = tabString,
+				Tuning = TuningScheme.Standard
+			};
+
+			playableSequence.ConvertTabsToNoteSequence(new Guitar(), tabs);
+
+			AssertNoteGroups(expectedGroups, playableSequence.NoteSequence);
+		}
+
+		private static PlayableSequence CreateSequence()
+		{
+			return new PlayableSequence
+			{
+				MeasureTime = 1000,
+				Octave = 3,
+				InstrumentType = InstrumentType.Horn,
+				A4Reference = 440
+			};
+		}
+
+		private static void AssertNoteGroups(string expectedGroups, IEnumerable<NoteGroup> actualGroups)
+		{
+			var expected = expectedGroups.Split('|').Select(group => group.Split(',')).ToArray();
+			var actual = actualGroups.Select(group => group.Notes).ToArray();
+
+			Assert.Equal(expected.Length, actual.Length);
+			for (var index = 0; index < expected.Length; index++)
+			{
+				Assert.Equal(expected[index], actual[index]);
+			}
+		}
+	}
+}

--- a/NoteScalerTests/Services/PlayableSequencePlaybackTests.cs
+++ b/NoteScalerTests/Services/PlayableSequencePlaybackTests.cs
@@ -1,0 +1,84 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using NoteScaler.Services;
+	using NoteScalerTests.Support;
+	using System.Collections.Generic;
+	using System.Linq;
+	using Xunit;
+
+	public class PlayableSequencePlaybackTests
+	{
+		[Fact]
+		public void Prepare_CreatesPlayerGuitarAndCompositeNotes()
+		{
+			var player = new TestPlayer();
+			var playableSequence = CreateSequence(player);
+			playableSequence.ConvertSongNotesToNoteSequence(new SongKey("Test", "C,E,G"));
+
+			playableSequence.Prepare();
+
+			Assert.Same(player, playableSequence.NotePlayer);
+			Assert.IsType<Guitar>(playableSequence.Guitar);
+			Assert.Equal(3, playableSequence.CompositeNotes.Count());
+		}
+
+		[Theory]
+		[InlineData(1, 2)]
+		[InlineData(2, 4)]
+		public void Play_RepeatsPreparedCompositeNotes(int repeat, int expectedPlayCount)
+		{
+			var player = new TestPlayer();
+			var playableSequence = CreateSequence(player);
+			playableSequence.Repeat = repeat;
+			playableSequence.ConvertSongNotesToNoteSequence(new SongKey("Test", "C,E"));
+			playableSequence.Prepare();
+
+			playableSequence.Play();
+
+			Assert.Equal(expectedPlayCount, player.PlayCount);
+		}
+
+		[Fact]
+		public void Play_RaisesStartAndStopEventsForPreparedSequence()
+		{
+			var player = new TestPlayer();
+			var playableSequence = CreateSequence(player);
+			var events = new List<PlayableEventType>();
+			playableSequence.PlayableSequenceEvent += (_, e) => events.Add(e.EventType);
+			playableSequence.ConvertSongNotesToNoteSequence(new SongKey("Test", "C"));
+			playableSequence.Prepare();
+
+			playableSequence.Play();
+
+			Assert.Contains(PlayableEventType.StartSequence, events);
+			Assert.Contains(PlayableEventType.StopSequence, events);
+		}
+
+		[Fact]
+		public void Play_RaisesErrorWhenThereAreNoCompositeNotes()
+		{
+			var playableSequence = CreateSequence(new TestPlayer());
+			PlayableSequenceEvent captured = null;
+			playableSequence.PlayableSequenceEvent += (_, e) => captured = e;
+
+			playableSequence.Play();
+
+			Assert.NotNull(captured);
+			Assert.Equal(PlayableEventType.Error, captured.EventType);
+			Assert.Equal("There are no notes to play", captured.EventDetails);
+		}
+
+		private static PlayableSequence CreateSequence(TestPlayer player)
+		{
+			return new PlayableSequence(() => player, () => new Guitar())
+			{
+				MeasureTime = 1000,
+				Octave = 3,
+				InstrumentType = InstrumentType.Horn,
+				A4Reference = 440
+			};
+		}
+	}
+}

--- a/NoteScalerTests/Services/SimpleServiceCoverageTests.cs
+++ b/NoteScalerTests/Services/SimpleServiceCoverageTests.cs
@@ -1,0 +1,60 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Players;
+	using NoteScaler.Services;
+	using System;
+	using System.IO;
+	using Xunit;
+
+	public class SimpleServiceCoverageTests
+	{
+		[Fact]
+		public void ConsoleOutputService_WritesMessageAndRestoresColor()
+		{
+			var service = new ConsoleOutputService();
+			var originalColor = Console.ForegroundColor;
+			using var writer = new StringWriter();
+			var originalOut = Console.Out;
+			Console.SetOut(writer);
+			try
+			{
+				service.WriteMessage("hello", ConsoleColor.Green);
+			}
+			finally
+			{
+				Console.SetOut(originalOut);
+			}
+
+			Assert.Contains("hello", writer.ToString());
+			Assert.Equal(originalColor, Console.ForegroundColor);
+		}
+
+		[Fact]
+		public void SignalNotePlayerFactory_CreatesSignalNotePlayer()
+		{
+			var factory = new SignalNotePlayerFactory();
+
+			var player = factory.Create();
+
+			Assert.IsType<SignalNotePlayer>(player);
+		}
+
+		[Fact]
+		public void MidiNotePlayer_ReportsPauseAndStopSupport()
+		{
+			var player = new MidiNotePlayer();
+
+			Assert.True(player.CanPause);
+			Assert.True(player.CanStop);
+		}
+
+		[Fact]
+		public void SignalNotePlayer_ReportsNoPauseOrStopSupport()
+		{
+			var player = new SignalNotePlayer();
+
+			Assert.False(player.CanPause);
+			Assert.False(player.CanStop);
+		}
+	}
+}

--- a/NoteScalerTests/Support/TestConsoleOutputService.cs
+++ b/NoteScalerTests/Support/TestConsoleOutputService.cs
@@ -1,0 +1,18 @@
+namespace NoteScalerTests.Support
+{
+	using NoteScaler.Services.Interfaces;
+	using System;
+	using System.Collections.Generic;
+
+	public sealed class TestConsoleOutputService : IConsoleOutputService
+	{
+		private readonly List<string> messages = new List<string>();
+
+		public IReadOnlyList<string> Messages => messages;
+
+		public void WriteMessage(string message, ConsoleColor textColor = ConsoleColor.White)
+		{
+			messages.Add(message);
+		}
+	}
+}

--- a/NoteScalerTests/Support/TestPlayer.cs
+++ b/NoteScalerTests/Support/TestPlayer.cs
@@ -1,0 +1,34 @@
+namespace NoteScalerTests.Support
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Interfaces;
+	using NoteScaler.Models;
+	using System.Collections.Generic;
+	using System.Linq;
+	using static NoteScaler.Services.PlayEngineBase;
+
+	public sealed class TestPlayer : IPlayer
+	{
+		public bool CanPause => true;
+		public bool CanStop => true;
+		public int PlayCount { get; private set; }
+		public IEnumerable<FrequencyDuration> LastNotes { get; private set; }
+		public InstrumentType LastInstrument { get; private set; }
+		public event PlayerEventHandler PlayerEvent;
+
+		public void Pause()
+		{
+		}
+
+		public void Play(IEnumerable<FrequencyDuration> noteList, InstrumentType instrument)
+		{
+			PlayCount++;
+			LastNotes = noteList.ToArray();
+			LastInstrument = instrument;
+		}
+
+		public void Stop()
+		{
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- addresses #20
- adds data-driven coverage for `MusicNote` parsing, frequency, scale, and chord behavior
- adds coverage for `Tablature.FixUp` default version and speed propagation behavior
- adds coverage for `PlayableSequence` song/tab conversion and playback/event behavior
- adds coverage for `CompositeNote` parsing/delegation behavior
- adds coverage for `PlayEngineBase` pause/stop/play event behavior
- adds runner coverage for invalid-note, missing-file, song-file, and tab-file command paths
- adds focused coverage for guitar formatting/error paths and simple service boundaries
- adds reusable test doubles for player and console output behavior

## Notes
- Test-focused PR only.
- No production code changes.
- No merge to `master`.

## Validation
- Shared CI passed.
- Line coverage is 81.2% (641 of 789 coverable lines).
- Branch coverage is 66.5% (187 of 281 branches).