### PR TITLE
Fix note playback sequence loading crash

### DIFF
--- a/NoteScaler/Services/PlayableSequence.cs
+++ b/NoteScaler/Services/PlayableSequence.cs
@@ -122,7 +122,7 @@
 		/// <param name="sequence"></param>
 		public void LoadSequenceFromString(IEnumerable<string> sequence)
 		{
-			Song.SetNoteSequence(sequence.ToArray());
+			NoteSequence = CreatePlayableNotesFromSongNotes(sequence.ToArray());
 			PrepareSequence();
 			PlayableSequenceEvent?.Invoke(this, new PlayableSequenceEvent()
 			{

--- a/NoteScalerTests/Services/PlayableSequenceAdditionalTests.cs
+++ b/NoteScalerTests/Services/PlayableSequenceAdditionalTests.cs
@@ -42,7 +42,7 @@ namespace NoteScalerTests.Services
 		}
 
 		[Fact]
-		public void LoadSequenceFromString_RaisesEventForCurrentNoteSequence()
+		public void LoadSequenceFromString_LoadsRequestedSequenceAndRaisesEvent()
 		{
 			var playableSequence = CreateSequence(new TestPlayer());
 			PlayableSequenceEvent captured = null;
@@ -53,8 +53,9 @@ namespace NoteScalerTests.Services
 
 			Assert.NotNull(captured);
 			Assert.Equal(PlayableEventType.SequenceLoaded, captured.EventType);
-			Assert.Equal("1 Notes loaded.", captured.EventDetails);
-			Assert.Equal(new[] { "C3-1000" }, playableSequence.NoteSequence.Single().Notes);
+			Assert.Equal("2 Notes loaded.", captured.EventDetails);
+			Assert.Equal(new[] { "D3-1000" }, playableSequence.NoteSequence.First().Notes);
+			Assert.Equal(new[] { "E3-500" }, playableSequence.NoteSequence.Last().Notes);
 		}
 
 		[Fact]

--- a/NoteScalerTests/Services/PlayableSequenceConversionTests.cs
+++ b/NoteScalerTests/Services/PlayableSequenceConversionTests.cs
@@ -3,6 +3,7 @@ namespace NoteScalerTests.Services
 	using NoteScaler.Enums;
 	using NoteScaler.Models;
 	using NoteScaler.Services;
+	using System;
 	using System.Collections.Generic;
 	using System.Linq;
 	using Xunit;
@@ -19,6 +20,19 @@ namespace NoteScalerTests.Services
 
 			playableSequence.ConvertSongNotesToNoteSequence(song);
 
+			AssertNoteGroups(expectedGroups, playableSequence.NoteSequence);
+		}
+
+		[Theory]
+		[InlineData("C,D-0.5,E4-2", "C3-1000|D3-500|E4-2000")]
+		[InlineData("C|E|G,A", "C3-1000,E3-1000,G3-1000|A3-1000")]
+		public void LoadSequenceFromString_ConvertsSongNotationWhenSongHasNotBeenInitialized(string sequence, string expectedGroups)
+		{
+			var playableSequence = CreateSequence();
+
+			var exception = Record.Exception(() => playableSequence.LoadSequenceFromString(sequence.Split(',')));
+
+			Assert.Null(exception);
 			AssertNoteGroups(expectedGroups, playableSequence.NoteSequence);
 		}
 


### PR DESCRIPTION
## Summary
- addresses issue 25
- adds a regression test for fresh `PlayableSequence.LoadSequenceFromString` usage
- changes `LoadSequenceFromString` to populate `NoteSequence` directly
- updates the existing sequence-loading test for the corrected behavior

## Validation
- CI pending.

No merge to master.