### PR TITLE
Fix issue 34 octave note handling

### DIFF
--- a/NoteScaler/Services/NoteScalerRunner.cs
+++ b/NoteScaler/Services/NoteScalerRunner.cs
@@ -12,6 +12,9 @@ namespace NoteScaler.Services
 
 	public sealed class NoteScalerRunner : INoteScalerRunner
 	{
+		private const int MINIMUM_SCALE_STARTING_OCTAVE = 0;
+		private const int MAXIMUM_SCALE_STARTING_OCTAVE = 10;
+
 		private readonly ICommandLineOptionsService commandLineOptionsService;
 		private readonly IPlayableSequenceFactory playableSequenceFactory;
 		private readonly IStringInstrumentFactory stringInstrumentFactory;
@@ -48,7 +51,7 @@ namespace NoteScaler.Services
 				var playableSequence = playableSequenceFactory.Create(options, a4Reference);
 				playableSequence.PlayableSequenceEvent += PlayableSequence_PlayableSequenceEvent;
 
-				PlayNoteAsRequired(options.Note, a4Reference, playableSequence);
+				PlayNoteAsRequired(options.Note, options.Octave.GetValueOrDefault(), a4Reference, playableSequence);
 				PlayTabAsRequired(tabName, playableSequence);
 				PlaySongAsRequired(key, fileName, playableSequence);
 			}
@@ -112,11 +115,19 @@ namespace NoteScaler.Services
 			}
 		}
 
-		private void PlayNoteAsRequired(string note, int a4Reference, PlayableSequence playableSequence)
+		private void PlayNoteAsRequired(string note, int octave, int a4Reference, PlayableSequence playableSequence)
 		{
 			if (note != null)
 			{
-				var musicNote = MusicNote.Create(note, a4Reference);
+				var effectiveOctave = GetEffectiveOctave(note, octave);
+				if (!IsValidScaleStartingOctave(effectiveOctave))
+				{
+					consoleOutputService.WriteMessage($"Octave {effectiveOctave} is out of range. Valid scale starting octaves are {MINIMUM_SCALE_STARTING_OCTAVE} through {MAXIMUM_SCALE_STARTING_OCTAVE}.", ConsoleColor.Red);
+					return;
+				}
+
+				var noteToCreate = GetNoteWithOctave(note, octave);
+				var musicNote = MusicNote.Create(noteToCreate, a4Reference);
 				if (musicNote?.IsValid ?? false)
 				{
 					ShowNote(musicNote);
@@ -139,7 +150,7 @@ namespace NoteScaler.Services
 				}
 				else
 				{
-					consoleOutputService.WriteMessage($"{note} is NOT a valid note!", ConsoleColor.Red);
+					consoleOutputService.WriteMessage($"{noteToCreate} is NOT a valid note!", ConsoleColor.Red);
 				}
 			}
 		}
@@ -223,6 +234,32 @@ namespace NoteScaler.Services
 			consoleOutputService.WriteMessage($"The relative minor is {relativeMinor}m");
 			consoleOutputService.WriteMessage($"The relative minor scale is {string.Join(',', musicNote.RelativeMinorScale)}");
 			consoleOutputService.WriteMessage($"The relative Major to the minor is {relativeMajor}");
+		}
+
+		private static int GetEffectiveOctave(string note, int octave)
+		{
+			if (!NoteContainsOctave(note))
+			{
+				return octave;
+			}
+
+			var octaveString = new string(note.Where(ch => char.IsDigit(ch)).ToArray());
+			return int.Parse(octaveString);
+		}
+
+		private static string GetNoteWithOctave(string note, int octave)
+		{
+			return NoteContainsOctave(note) ? note : $"{note}{octave}";
+		}
+
+		private static bool IsValidScaleStartingOctave(int octave)
+		{
+			return octave >= MINIMUM_SCALE_STARTING_OCTAVE && octave <= MAXIMUM_SCALE_STARTING_OCTAVE;
+		}
+
+		private static bool NoteContainsOctave(string note)
+		{
+			return note.Any(ch => char.IsDigit(ch));
 		}
 	}
 }

--- a/NoteScaler/Services/NoteScalerRunner.cs
+++ b/NoteScaler/Services/NoteScalerRunner.cs
@@ -152,7 +152,7 @@ namespace NoteScaler.Services
 				}
 				else
 				{
-					consoleOutputService.WriteMessage($"{noteToCreate} is NOT a valid note!", ConsoleColor.Red);
+					consoleOutputService.WriteMessage($"{note} is NOT a valid note!", ConsoleColor.Red);
 				}
 			}
 		}

--- a/NoteScaler/Services/NoteScalerRunner.cs
+++ b/NoteScaler/Services/NoteScalerRunner.cs
@@ -267,11 +267,6 @@ namespace NoteScaler.Services
 		private static IEnumerable<string> ApplyStartingOctave(IEnumerable<string> notes, int startingOctave)
 		{
 			var noteArray = notes.ToArray();
-			if (!noteArray.Any())
-			{
-				return noteArray;
-			}
-
 			var firstOctave = GetNoteOctave(noteArray.First());
 			return noteArray.Select(note => $"{GetNoteName(note)}{startingOctave + GetNoteOctave(note) - firstOctave}");
 		}
@@ -284,7 +279,7 @@ namespace NoteScaler.Services
 		private static int GetNoteOctave(string note)
 		{
 			var octaveString = new string(note.Where(ch => char.IsDigit(ch)).ToArray());
-			return string.IsNullOrEmpty(octaveString) ? 0 : int.Parse(octaveString);
+			return int.Parse(octaveString);
 		}
 	}
 }

--- a/NoteScaler/Services/NoteScalerRunner.cs
+++ b/NoteScaler/Services/NoteScalerRunner.cs
@@ -7,6 +7,7 @@ namespace NoteScaler.Services
 	using NoteScaler.Models;
 	using NoteScaler.Services.Interfaces;
 	using System;
+	using System.Collections.Generic;
 	using System.Linq;
 	using System.Threading;
 
@@ -131,20 +132,21 @@ namespace NoteScaler.Services
 				if (musicNote?.IsValid ?? false)
 				{
 					ShowNote(musicNote);
-					var musicNotes = musicNote.MajorScale.ToArray();
+					var musicNotes = ApplyStartingOctave(musicNote.MajorScale, musicNote.DesiredOctave).ToArray();
 					consoleOutputService.WriteMessage($"Playing Major Scale: {string.Join(',', musicNotes)}");
-					playableSequence.LoadSequenceFromString(musicNote.MajorScale);
+					playableSequence.LoadSequenceFromString(musicNotes);
 					playableSequence.Prepare();
 					playableSequence.Play();
 					Thread.Sleep(1000);
-					musicNotes = musicNote.MinorScale.ToArray();
+					musicNotes = ApplyStartingOctave(musicNote.MinorScale, musicNote.DesiredOctave).ToArray();
 					consoleOutputService.WriteMessage($"Playing Minor Scale: {string.Join(',', musicNotes)}");
-					playableSequence.LoadSequenceFromString(musicNote.MinorScale);
+					playableSequence.LoadSequenceFromString(musicNotes);
 					playableSequence.Prepare();
 					playableSequence.Play();
 					Thread.Sleep(1000);
-					consoleOutputService.WriteMessage($"Playing Relative Minor Scale {musicNote.RelativeMinor}m: {string.Join(',', musicNote.RelativeMinorScale)}");
-					playableSequence.LoadSequenceFromString(musicNote.RelativeMinorScale);
+					musicNotes = ApplyStartingOctave(musicNote.RelativeMinorScale, musicNote.DesiredOctave).ToArray();
+					consoleOutputService.WriteMessage($"Playing Relative Minor Scale {musicNote.RelativeMinor}m: {string.Join(',', musicNotes)}");
+					playableSequence.LoadSequenceFromString(musicNotes);
 					playableSequence.Prepare();
 					playableSequence.Play();
 				}
@@ -228,11 +230,11 @@ namespace NoteScaler.Services
 			consoleOutputService.WriteMessage($"Of the 12 natural, flat and sharp notes {musicNote} has {musicNote.NoteBefore} before it and {musicNote.NoteAfter} after it.");
 			consoleOutputService.WriteMessage($"Of the 7 notes in the {musicNote} scale {musicNote} has {musicNote.MajorNoteBefore} before it and {musicNote.MajorNoteAfter} after it.");
 			consoleOutputService.WriteMessage($"Of the 7 notes in the {musicNote}m scale {musicNote} has {musicNote.MinorNoteBefore} before it and {musicNote.MinorNoteAfter} after it.");
-			consoleOutputService.WriteMessage($"Notes in {musicNote} are: {string.Join(',', musicNote.MajorScale)}");
-			consoleOutputService.WriteMessage($"Notes in {musicNote}m are: {string.Join(',', musicNote.MinorScale)}");
-			consoleOutputService.WriteMessage($"Major Chord: {string.Join(',', musicNote.MajorChord15)} minor Chord: {string.Join(',', musicNote.MinorChord15)}");
+			consoleOutputService.WriteMessage($"Notes in {musicNote} are: {string.Join(',', ApplyStartingOctave(musicNote.MajorScale, musicNote.DesiredOctave))}");
+			consoleOutputService.WriteMessage($"Notes in {musicNote}m are: {string.Join(',', ApplyStartingOctave(musicNote.MinorScale, musicNote.DesiredOctave))}");
+			consoleOutputService.WriteMessage($"Major Chord: {string.Join(',', ApplyStartingOctave(musicNote.MajorChord15, musicNote.DesiredOctave))} minor Chord: {string.Join(',', ApplyStartingOctave(musicNote.MinorChord15, musicNote.DesiredOctave))}");
 			consoleOutputService.WriteMessage($"The relative minor is {relativeMinor}m");
-			consoleOutputService.WriteMessage($"The relative minor scale is {string.Join(',', musicNote.RelativeMinorScale)}");
+			consoleOutputService.WriteMessage($"The relative minor scale is {string.Join(',', ApplyStartingOctave(musicNote.RelativeMinorScale, musicNote.DesiredOctave))}");
 			consoleOutputService.WriteMessage($"The relative Major to the minor is {relativeMajor}");
 		}
 
@@ -260,6 +262,29 @@ namespace NoteScaler.Services
 		private static bool NoteContainsOctave(string note)
 		{
 			return note.Any(ch => char.IsDigit(ch));
+		}
+
+		private static IEnumerable<string> ApplyStartingOctave(IEnumerable<string> notes, int startingOctave)
+		{
+			var noteArray = notes.ToArray();
+			if (!noteArray.Any())
+			{
+				return noteArray;
+			}
+
+			var firstOctave = GetNoteOctave(noteArray.First());
+			return noteArray.Select(note => $"{GetNoteName(note)}{startingOctave + GetNoteOctave(note) - firstOctave}");
+		}
+
+		private static string GetNoteName(string note)
+		{
+			return new string(note.Where(ch => !char.IsDigit(ch)).ToArray());
+		}
+
+		private static int GetNoteOctave(string note)
+		{
+			var octaveString = new string(note.Where(ch => char.IsDigit(ch)).ToArray());
+			return string.IsNullOrEmpty(octaveString) ? 0 : int.Parse(octaveString);
 		}
 	}
 }

--- a/NoteScalerTests/Models/CapturingConsoleOutputService.cs
+++ b/NoteScalerTests/Models/CapturingConsoleOutputService.cs
@@ -1,0 +1,16 @@
+namespace NoteScalerTests.Models
+{
+	using NoteScaler.Services.Interfaces;
+	using System;
+	using System.Collections.Generic;
+
+	public sealed class CapturingConsoleOutputService : IConsoleOutputService
+	{
+		public List<string> Messages { get; } = new List<string>();
+
+		public void WriteMessage(string message, ConsoleColor textColor = ConsoleColor.White)
+		{
+			Messages.Add(message);
+		}
+	}
+}

--- a/NoteScalerTests/Models/NoOpPlayer.cs
+++ b/NoteScalerTests/Models/NoOpPlayer.cs
@@ -1,0 +1,20 @@
+namespace NoteScalerTests.Models
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Interfaces;
+	using NoteScaler.Models;
+	using NoteScaler.Services;
+	using System.Collections.Generic;
+
+	public sealed class NoOpPlayer : PlayEngineBase, IPlayer
+	{
+		public override bool CanPause => false;
+
+		public override bool CanStop => false;
+
+		public override void Play(IEnumerable<FrequencyDuration> noteList, InstrumentType instrument)
+		{
+			base.Play(noteList, instrument);
+		}
+	}
+}

--- a/NoteScalerTests/Models/TestPlayableSequenceFactory.cs
+++ b/NoteScalerTests/Models/TestPlayableSequenceFactory.cs
@@ -1,0 +1,21 @@
+namespace NoteScalerTests.Models
+{
+	using NoteScaler.Config;
+	using NoteScaler.Enums;
+	using NoteScaler.Services;
+	using NoteScaler.Services.Interfaces;
+
+	public sealed class TestPlayableSequenceFactory : IPlayableSequenceFactory
+	{
+		public PlayableSequence Create(NoteScalerOptions options, int a4Reference)
+		{
+			return new PlayableSequence(() => new NoOpPlayer(), () => new Guitar())
+			{
+				MeasureTime = options.Speed.GetValueOrDefault(),
+				Octave = options.Octave.GetValueOrDefault(),
+				A4Reference = a4Reference,
+				InstrumentType = options.Instrument
+			};
+		}
+	}
+}

--- a/NoteScalerTests/Models/UnusedStringInstrumentFactory.cs
+++ b/NoteScalerTests/Models/UnusedStringInstrumentFactory.cs
@@ -1,0 +1,15 @@
+namespace NoteScalerTests.Models
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Interfaces;
+	using NoteScaler.Services.Interfaces;
+	using System;
+
+	public sealed class UnusedStringInstrumentFactory : IStringInstrumentFactory
+	{
+		public IStringInstrument Create(TuningScheme tuningScheme, int numberOfFrets)
+		{
+			throw new InvalidOperationException($"The string instrument factory should not be used by {nameof(UnusedStringInstrumentFactory)}.");
+		}
+	}
+}

--- a/NoteScalerTests/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/NoteScalerRunnerTests.cs
@@ -1,13 +1,7 @@
-﻿namespace NoteScalerTests
+namespace NoteScalerTests
 {
-	using NoteScaler.Config;
-	using NoteScaler.Enums;
-	using NoteScaler.Interfaces;
-	using NoteScaler.Models;
 	using NoteScaler.Services;
-	using NoteScaler.Services.Interfaces;
-	using System;
-	using System.Collections.Generic;
+	using NoteScalerTests.Models;
 	using Xunit;
 
 	public class NoteScalerRunnerTests
@@ -28,50 +22,6 @@
 
 			Assert.Contains(expectedCurrentNoteMessage, consoleOutputService.Messages);
 			Assert.Contains(expectedMajorScaleMessage, consoleOutputService.Messages);
-		}
-
-		private sealed class CapturingConsoleOutputService : IConsoleOutputService
-		{
-			public List<string> Messages { get; } = new List<string>();
-
-			public void WriteMessage(string message, ConsoleColor textColor = ConsoleColor.White)
-			{
-				Messages.Add(message);
-			}
-		}
-
-		private sealed class TestPlayableSequenceFactory : IPlayableSequenceFactory
-		{
-			public PlayableSequence Create(NoteScalerOptions options, int a4Reference)
-			{
-				return new PlayableSequence(() => new NoOpPlayer(), () => new Guitar())
-				{
-					MeasureTime = options.Speed.GetValueOrDefault(),
-					Octave = options.Octave.GetValueOrDefault(),
-					A4Reference = a4Reference,
-					InstrumentType = options.Instrument
-				};
-			}
-		}
-
-		private sealed class UnusedStringInstrumentFactory : IStringInstrumentFactory
-		{
-			public IStringInstrument Create(TuningScheme tuningScheme, int numberOfFrets)
-			{
-				throw new InvalidOperationException($"The string instrument factory should not be used by {nameof(NoteScalerRunnerTests)}.");
-			}
-		}
-
-		private sealed class NoOpPlayer : PlayEngineBase, IPlayer
-		{
-			public override bool CanPause => false;
-
-			public override bool CanStop => false;
-
-			public override void Play(IEnumerable<FrequencyDuration> noteList, InstrumentType instrument)
-			{
-				base.Play(noteList, instrument);
-			}
 		}
 	}
 }

--- a/NoteScalerTests/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/NoteScalerRunnerTests.cs
@@ -28,9 +28,9 @@ namespace NoteScalerTests
 		}
 
 		[Theory]
-		[InlineData("-1")]
-		[InlineData("11")]
-		public void Run_WhenNoteOptionIsUsedWithOutOfRangeOctave_WritesValidationMessage(string octave)
+		[InlineData(new[] { "--note", "C", "--octave=-1" }, "-1")]
+		[InlineData(new[] { "--note", "C", "--octave", "11" }, "11")]
+		public void Run_WhenNoteOptionIsUsedWithOutOfRangeOctave_WritesValidationMessage(string[] args, string expectedOctave)
 		{
 			var consoleOutputService = new CapturingConsoleOutputService();
 			var runner = new NoteScalerRunner(
@@ -39,9 +39,9 @@ namespace NoteScalerTests
 				new UnusedStringInstrumentFactory(),
 				consoleOutputService);
 
-			runner.Run(new[] { "--note", "C", "--octave", octave });
+			runner.Run(args);
 
-			Assert.Contains($"Octave {octave} is out of range. Valid scale starting octaves are 0 through 10.", consoleOutputService.Messages);
+			Assert.Contains($"Octave {expectedOctave} is out of range. Valid scale starting octaves are 0 through 10.", consoleOutputService.Messages);
 		}
 	}
 }

--- a/NoteScalerTests/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/NoteScalerRunnerTests.cs
@@ -7,7 +7,10 @@ namespace NoteScalerTests
 	public class NoteScalerRunnerTests
 	{
 		[Theory]
+		[InlineData(new[] { "--note", "C", "--octave", "0" }, "C0-500ms is the current note", "Playing Major Scale: C0,D0,E0,F0,G0,A0,B0,C1")]
 		[InlineData(new[] { "--note", "C", "--octave", "3" }, "C3-500ms is the current note", "Playing Major Scale: C3,D3,E3,F3,G3,A3,B3,C4")]
+		[InlineData(new[] { "--note", "C", "--octave", "5" }, "C5-500ms is the current note", "Playing Major Scale: C5,D5,E5,F5,G5,A5,B5,C6")]
+		[InlineData(new[] { "--note", "C", "--octave", "10" }, "C10-500ms is the current note", "Playing Major Scale: C10,D10,E10,F10,G10,A10,B10,C11")]
 		[InlineData(new[] { "--note", "C" }, "C3-500ms is the current note", "Playing Major Scale: C3,D3,E3,F3,G3,A3,B3,C4")]
 		public void Run_WhenNoteOptionIsUsed_StartsAtSpecifiedOrDefaultOctave(string[] args, string expectedCurrentNoteMessage, string expectedMajorScaleMessage)
 		{
@@ -22,6 +25,23 @@ namespace NoteScalerTests
 
 			Assert.Contains(expectedCurrentNoteMessage, consoleOutputService.Messages);
 			Assert.Contains(expectedMajorScaleMessage, consoleOutputService.Messages);
+		}
+
+		[Theory]
+		[InlineData("-1")]
+		[InlineData("11")]
+		public void Run_WhenNoteOptionIsUsedWithOutOfRangeOctave_WritesValidationMessage(string octave)
+		{
+			var consoleOutputService = new CapturingConsoleOutputService();
+			var runner = new NoteScalerRunner(
+				new CommandLineOptionsService(),
+				new TestPlayableSequenceFactory(),
+				new UnusedStringInstrumentFactory(),
+				consoleOutputService);
+
+			runner.Run(new[] { "--note", "C", "--octave", octave });
+
+			Assert.Contains($"Octave {octave} is out of range. Valid scale starting octaves are 0 through 10.", consoleOutputService.Messages);
 		}
 	}
 }

--- a/NoteScalerTests/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/NoteScalerRunnerTests.cs
@@ -12,6 +12,7 @@ namespace NoteScalerTests
 		[InlineData(new[] { "--note", "C", "--octave", "5" }, "C5-500ms is the current note", "Playing Major Scale: C5,D5,E5,F5,G5,A5,B5,C6")]
 		[InlineData(new[] { "--note", "C", "--octave", "10" }, "C10-500ms is the current note", "Playing Major Scale: C10,D10,E10,F10,G10,A10,B10,C11")]
 		[InlineData(new[] { "--note", "C" }, "C3-500ms is the current note", "Playing Major Scale: C3,D3,E3,F3,G3,A3,B3,C4")]
+		[InlineData(new[] { "--note", "C5" }, "C5-500ms is the current note", "Playing Major Scale: C5,D5,E5,F5,G5,A5,B5,C6")]
 		public void Run_WhenNoteOptionIsUsed_StartsAtSpecifiedOrDefaultOctave(string[] args, string expectedCurrentNoteMessage, string expectedMajorScaleMessage)
 		{
 			var consoleOutputService = new CapturingConsoleOutputService();
@@ -30,6 +31,7 @@ namespace NoteScalerTests
 		[Theory]
 		[InlineData(new[] { "--note", "C", "--octave=-1" }, "-1")]
 		[InlineData(new[] { "--note", "C", "--octave", "11" }, "11")]
+		[InlineData(new[] { "--note", "C11" }, "11")]
 		public void Run_WhenNoteOptionIsUsedWithOutOfRangeOctave_WritesValidationMessage(string[] args, string expectedOctave)
 		{
 			var consoleOutputService = new CapturingConsoleOutputService();

--- a/NoteScalerTests/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/NoteScalerRunnerTests.cs
@@ -1,0 +1,77 @@
+﻿namespace NoteScalerTests
+{
+	using NoteScaler.Config;
+	using NoteScaler.Enums;
+	using NoteScaler.Interfaces;
+	using NoteScaler.Models;
+	using NoteScaler.Services;
+	using NoteScaler.Services.Interfaces;
+	using System;
+	using System.Collections.Generic;
+	using Xunit;
+
+	public class NoteScalerRunnerTests
+	{
+		[Theory]
+		[InlineData(new[] { "--note", "C", "--octave", "3" }, "C3-500ms is the current note", "Playing Major Scale: C3,D3,E3,F3,G3,A3,B3,C4")]
+		[InlineData(new[] { "--note", "C" }, "C3-500ms is the current note", "Playing Major Scale: C3,D3,E3,F3,G3,A3,B3,C4")]
+		public void Run_WhenNoteOptionIsUsed_StartsAtSpecifiedOrDefaultOctave(string[] args, string expectedCurrentNoteMessage, string expectedMajorScaleMessage)
+		{
+			var consoleOutputService = new CapturingConsoleOutputService();
+			var runner = new NoteScalerRunner(
+				new CommandLineOptionsService(),
+				new TestPlayableSequenceFactory(),
+				new UnusedStringInstrumentFactory(),
+				consoleOutputService);
+
+			runner.Run(args);
+
+			Assert.Contains(expectedCurrentNoteMessage, consoleOutputService.Messages);
+			Assert.Contains(expectedMajorScaleMessage, consoleOutputService.Messages);
+		}
+
+		private sealed class CapturingConsoleOutputService : IConsoleOutputService
+		{
+			public List<string> Messages { get; } = new List<string>();
+
+			public void WriteMessage(string message, ConsoleColor textColor = ConsoleColor.White)
+			{
+				Messages.Add(message);
+			}
+		}
+
+		private sealed class TestPlayableSequenceFactory : IPlayableSequenceFactory
+		{
+			public PlayableSequence Create(NoteScalerOptions options, int a4Reference)
+			{
+				return new PlayableSequence(() => new NoOpPlayer(), () => new Guitar())
+				{
+					MeasureTime = options.Speed.GetValueOrDefault(),
+					Octave = options.Octave.GetValueOrDefault(),
+					A4Reference = a4Reference,
+					InstrumentType = options.Instrument
+				};
+			}
+		}
+
+		private sealed class UnusedStringInstrumentFactory : IStringInstrumentFactory
+		{
+			public IStringInstrument Create(TuningScheme tuningScheme, int numberOfFrets)
+			{
+				throw new InvalidOperationException($"The string instrument factory should not be used by {nameof(NoteScalerRunnerTests)}.");
+			}
+		}
+
+		private sealed class NoOpPlayer : PlayEngineBase, IPlayer
+		{
+			public override bool CanPause => false;
+
+			public override bool CanStop => false;
+
+			public override void Play(IEnumerable<FrequencyDuration> noteList, InstrumentType instrument)
+			{
+				base.Play(noteList, instrument);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #34 by applying the selected/default octave to the `--note` workflow.

## What is covered

- `notescaler --note C --octave 0` starts at `C0`.
- `notescaler --note C --octave 3` starts at `C3`.
- `notescaler --note C --octave 5` starts at `C5`.
- `notescaler --note C --octave 10` starts at `C10`.
- `notescaler --note C` defaults to `C3`.
- `--octave=-1` and `--octave 11` report an out-of-range validation message.

## Implementation notes

- The runner now creates the note with the effective octave.
- The runner also normalizes generated major, minor, and relative-minor scales to the selected starting octave before printing and playing them.
- Valid scale-starting octaves are currently `0` through `10`, because starting at `11` can generate scale notes into octave `12` while the note frequency table only supports up through octave `11`.