### PR TITLE
Split MusicNote responsibilities

### DIFF
--- a/NoteScaler/Models/NoteToken.cs
+++ b/NoteScaler/Models/NoteToken.cs
@@ -1,0 +1,54 @@
+namespace NoteScaler.Models
+{
+	using NoteScaler.Enums;
+	using System;
+	using System.Linq;
+
+	public sealed class NoteToken
+	{
+		private const string SHARP_NOTE = "#";
+		private const string FLAT_NOTE = "b";
+
+		private NoteToken(string name, int octave, bool hasOctave, ToneTypes toneType)
+		{
+			Name = name;
+			Octave = octave;
+			HasOctave = hasOctave;
+			ToneType = toneType;
+		}
+
+		public string Name { get; }
+		public int Octave { get; }
+		public bool HasOctave { get; }
+		public ToneTypes ToneType { get; }
+
+		public static NoteToken Parse(string token)
+		{
+			if (token == null)
+			{
+				throw new ArgumentNullException(nameof(token));
+			}
+
+			var name = new string(token.Where(ch => !char.IsDigit(ch)).ToArray());
+			var octaveString = new string(token.Where(ch => char.IsDigit(ch)).ToArray());
+			var hasOctave = !string.IsNullOrEmpty(octaveString);
+			var octave = hasOctave ? int.Parse(octaveString) : 0;
+			return new NoteToken(name, octave, hasOctave, GetToneType(name));
+		}
+
+		private static ToneTypes GetToneType(string name)
+		{
+			if (name.Contains(SHARP_NOTE))
+			{
+				return ToneTypes.Sharp;
+			}
+
+			if (name.Contains(FLAT_NOTE))
+			{
+				return ToneTypes.Flat;
+			}
+
+			return ToneTypes.Natural;
+		}
+	}
+}

--- a/NoteScaler/Services/MusicNote.cs
+++ b/NoteScaler/Services/MusicNote.cs
@@ -20,23 +20,14 @@
 		private const int ELEVENTH = 3;
 		private const int THIRTEENTH = 5;
 		private const int FIFTEENTH = 7;
-		private const string B_NOTE = "B";
-		private const string C_NOTE = "C";
-		private const string E_NOTE = "E";
-		private const string WHOLE_STEP = "W";
-		private const string HALF_STEP = "H";
 		private const string SHARP_NOTE = "#";
 		private const string FLAT_NOTE = "b";
-		private const char Separator = ',';
 		private const int POWER_CHORD = 2;
 		private const int MAJOR_MINOR_THREE_CHORD = 3;
 		private const int MAJOR_MINOR_FIVE_CHORD = 5;
 
-		private static readonly double NOTE_REF = 1.059463;
-		private static readonly string[] NotesFlat = new string[] { "C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B", "C" };
-		private static readonly string[] NotesSharp = new string[] { "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B", "C" };
-		private static readonly string MAJOR_SCALE = $"{WHOLE_STEP},{WHOLE_STEP},{HALF_STEP},{WHOLE_STEP},{WHOLE_STEP},{WHOLE_STEP},{HALF_STEP}";
-		private static readonly string MINOR_SCALE = $"{WHOLE_STEP},{HALF_STEP},{WHOLE_STEP},{WHOLE_STEP},{HALF_STEP},{WHOLE_STEP},{WHOLE_STEP}";
+		private static readonly MusicNoteFrequencyCalculator FrequencyCalculator = new MusicNoteFrequencyCalculator();
+		private static readonly MusicNoteScaleBuilder ScaleBuilder = new MusicNoteScaleBuilder();
 
 		private bool isValid = false;
 		private int desiredOctave = 0;
@@ -208,15 +199,16 @@
 		{
 			try
 			{
-				SetToneOfNote();
-				AdjustNoteOctave();
-				var flatNotes = NotesFlat.ToList();
-				var sharpNotes = NotesSharp.ToList();
-				int currentNoteIndex = SetupNotesScale(Key, out sharpNotes, out flatNotes);
-				FlatNotes = flatNotes;
-				SharpNotes = sharpNotes;
-				InitializeFrequencies(currentNoteIndex);
-				InitializeScalesAndKeys();
+				var token = NoteToken.Parse(Key);
+				Key = token.Name;
+				desiredOctave = token.Octave;
+				ToneType = token.ToneType;
+
+				var context = ScaleBuilder.GetNoteContext(Key);
+				FlatNotes = context.FlatNotes;
+				SharpNotes = context.SharpNotes;
+				Frequencies = FrequencyCalculator.CalculateFrequencies(context.NoteIndex, Reference);
+				InitializeScalesAndKeys(context);
 				isValid = true;
 			}
 			catch (Exception ex)
@@ -226,28 +218,10 @@
 			}
 		}
 
-		private int SetupNotesScale(string note, out List<string> sharpNotes, out List<string> flatNotes)
+		private void InitializeScalesAndKeys(MusicNoteScaleContext context)
 		{
-			var currentNoteIndex = GetNoteIndex(note, out sharpNotes, out flatNotes);
-			if (currentNoteIndex > 0)
-			{
-				var takeFlat = flatNotes.Count - currentNoteIndex - 1;
-				var notes = flatNotes.Skip(currentNoteIndex).Take(takeFlat).ToList();
-				notes.AddRange(flatNotes.Take(currentNoteIndex + 1).Select(note => $"{note}"));
-				flatNotes = notes;
-
-				var takeSharp = sharpNotes.Count - currentNoteIndex - 1;
-				notes = sharpNotes.Skip(currentNoteIndex).Take(takeSharp).ToList();
-				notes.AddRange(sharpNotes.Take(currentNoteIndex + 1).Select(note => $"{note}"));
-				sharpNotes = notes;
-			}
-			return currentNoteIndex;
-		}
-
-		private void InitializeScalesAndKeys()
-		{
-			minorScale = GetMinorScale(Key);
-			majorScale = GetMajorScale(Key);
+			minorScale = ScaleBuilder.BuildMinorScale(Key, ToneType, context);
+			majorScale = ScaleBuilder.BuildMajorScale(Key, ToneType, context);
 			relativeMinor = GetRelativeKey(false);
 			relativeMajor = GetRelativeKey(true);
 			noteBefore = GetNoteBefore(false);
@@ -258,118 +232,12 @@
 			majorNoteAfter = GetNoteAfter(true);
 			minorChord = GetMinorChord();
 			majorChord = GetMajorChord();
-			relativeMinorScale = GetRelativeMinorScale();
-		}
-
-		private IEnumerable<string> GetRelativeMinorScale()
-		{
-			var relativeMinorNote = GetRelativeKey();
-			if (relativeMinorNote.Any(ch => char.IsDigit(ch)))
-			{
-				relativeMinorNote = new String(relativeMinorNote.Where(ch => !char.IsDigit(ch)).ToArray());
-			}
-			var flatNotes = NotesFlat.ToList();
-			var sharpNotes = NotesSharp.ToList();
-			SetupNotesScale(relativeMinorNote, out sharpNotes, out flatNotes);
-			return GetScale(relativeMinorNote, false, IsFlat, flatNotes, sharpNotes);
-		}
-
-		private void InitializeFrequencies(int currentNoteIndex)
-		{
-			var frequencyList = GetFrequenciesFromReference().ToArray();
-			Frequencies = new float[]
-			{
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, -4),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, -3),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, -2),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, -1),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, 0),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, 1),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, 2),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, 3),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, 4),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, 5),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, 6),
-				frequencyList[currentNoteIndex] * (float)Math.Pow(2, 7)
-			};
-		}
-
-		private float[] GetFrequenciesFromReference()
-		{
-			var frequencyList = new float[NotesSharp.Length];
-			var a4Pos = Array.IndexOf(NotesSharp, "A");
-			NotesSharp.ToList().ForEach(note =>
-			{
-				var currentIndex = Array.IndexOf(NotesSharp, note);
-				double index = currentIndex - a4Pos;
-				if (index == 0)
-				{
-					frequencyList[currentIndex] = Reference;
-				}
-				else
-				{
-					frequencyList[currentIndex] = (float)(Reference * Math.Pow(NOTE_REF, index));
-				}
-			});
-			frequencyList[^1] = (float)(Reference * Math.Pow(NOTE_REF, 3));
-			return frequencyList;
-		}
-
-		private int GetNoteIndex(string note, out List<string> sharpNotes, out List<string> flatNotes)
-		{
-			sharpNotes = NotesSharp.ToList();
-			flatNotes = NotesFlat.ToList();
-			var currentSharpNoteIndex = sharpNotes.IndexOf(note);
-			var currentFlatNoteIndex = flatNotes.IndexOf(note);
-			var currentNoteIndex = currentSharpNoteIndex == -1 ? currentFlatNoteIndex : currentSharpNoteIndex;
-			if (currentNoteIndex == -1)
-			{
-				Error?.Invoke(this, new ArgumentException("Unable to find referenced note!", note));
-			}
-			return currentNoteIndex;
-		}
-
-		private void AdjustNoteOctave()
-		{
-			var testKey = Key;
-			if (testKey.Any(ch => char.IsDigit(ch)))
-			{
-				var rawNote = new String(testKey.Where(ch => !char.IsDigit(ch)).ToArray());
-				var octaveString = new String(testKey.Where(ch => char.IsDigit(ch)).ToArray());
-				desiredOctave = int.Parse(octaveString);
-				Key = rawNote;
-			}
-		}
-
-		private void SetToneOfNote()
-		{
-			if (Key.Contains(SHARP_NOTE))
-			{
-				ToneType = ToneTypes.Sharp;
-			}
-			else if (Key.Contains(FLAT_NOTE))
-			{
-				ToneType = ToneTypes.Flat;
-			}
-			else
-			{
-				ToneType = ToneTypes.Natural;
-			}
+			relativeMinorScale = ScaleBuilder.BuildRelativeMinorScale(majorScale, ToneType);
 		}
 
 		private string GetRelativeKey(bool forMajor = false)
 		{
 			return !forMajor ? MajorScale.ElementAt(RELATIVE_MINOR_POSITION) : MajorScale.ElementAt(RELATIVE_MAJOR_POSITION);
-		}
-
-		private IEnumerable<string> GetMajorScale(string note)
-		{
-			return GetScale(note, true, ToneType == ToneTypes.Flat);
-		}
-
-		private IEnumerable<string> GetMinorScale(string note)
-		{
-			return GetScale(note, false, ToneType == ToneTypes.Flat);
 		}
 
 		private string GetNoteBefore(bool useScale = true, bool useMinorScale = false)
@@ -431,50 +299,9 @@
 			}
 			else
 			{
-				noteList = IsNatural ? NotesFlat : IsSharp ? NotesSharp : NotesFlat;
+				noteList = IsNatural ? FlatNotes : IsSharp ? SharpNotes : FlatNotes;
 			}
 
-			return noteList;
-		}
-
-		private IEnumerable<string> GetScale(string note, bool isMajor = true, bool useFlats = false, IEnumerable<string> flatNotes = null, IEnumerable<string> sharpNotes = null)
-		{
-			List<string> scaleNotes;
-			int currentOctave = 0;
-			var noteList = new List<string>();
-			if (useFlats)
-			{
-				scaleNotes = (flatNotes ?? FlatNotes).ToList();
-			}
-			else
-			{
-				scaleNotes = (sharpNotes ?? SharpNotes).ToList();
-			}
-
-			int currentNotesInScale = 0;
-			int notesCounted = 0;
-			var currentScale = MAJOR_SCALE.Split(Separator);
-			if (!isMajor)
-			{
-				currentScale = MINOR_SCALE.Split(Separator);
-			}
-			noteList.Add($"{note}{currentOctave}");
-			while (noteList.Count() < 8)
-			{
-				int index = 1;
-				if (currentScale[currentNotesInScale] == WHOLE_STEP && (scaleNotes[notesCounted] != B_NOTE || scaleNotes[notesCounted] != E_NOTE))
-				{
-					index = 2;
-				}
-				notesCounted += index;
-				var newNote = scaleNotes.ElementAt(notesCounted);
-				if (newNote.Contains(C_NOTE) && currentOctave == 0)
-				{
-					currentOctave++;
-				}
-				noteList.Add($"{newNote}{currentOctave}");
-				currentNotesInScale++;
-			}
 			return noteList;
 		}
 

--- a/NoteScaler/Services/MusicNoteFrequencyCalculator.cs
+++ b/NoteScaler/Services/MusicNoteFrequencyCalculator.cs
@@ -1,0 +1,57 @@
+namespace NoteScaler.Services
+{
+	using System;
+	using System.Linq;
+
+	public sealed class MusicNoteFrequencyCalculator
+	{
+		private const double NOTE_REF = 1.059463;
+		private static readonly string[] NotesSharp = { "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B", "C" };
+
+		public float[] CalculateFrequencies(int noteIndex, int reference)
+		{
+			if (noteIndex < 0 || noteIndex >= NotesSharp.Length)
+			{
+				throw new ArgumentOutOfRangeException(nameof(noteIndex), noteIndex, "Note index is outside the supported note range.");
+			}
+
+			var frequencyList = GetFrequenciesFromReference(reference);
+			return new float[]
+			{
+				frequencyList[noteIndex] * (float)Math.Pow(2, -4),
+				frequencyList[noteIndex] * (float)Math.Pow(2, -3),
+				frequencyList[noteIndex] * (float)Math.Pow(2, -2),
+				frequencyList[noteIndex] * (float)Math.Pow(2, -1),
+				frequencyList[noteIndex] * (float)Math.Pow(2, 0),
+				frequencyList[noteIndex] * (float)Math.Pow(2, 1),
+				frequencyList[noteIndex] * (float)Math.Pow(2, 2),
+				frequencyList[noteIndex] * (float)Math.Pow(2, 3),
+				frequencyList[noteIndex] * (float)Math.Pow(2, 4),
+				frequencyList[noteIndex] * (float)Math.Pow(2, 5),
+				frequencyList[noteIndex] * (float)Math.Pow(2, 6),
+				frequencyList[noteIndex] * (float)Math.Pow(2, 7)
+			};
+		}
+
+		private static float[] GetFrequenciesFromReference(int reference)
+		{
+			var frequencyList = new float[NotesSharp.Length];
+			var a4Position = Array.IndexOf(NotesSharp, "A");
+			NotesSharp.ToList().ForEach(note =>
+			{
+				var currentIndex = Array.IndexOf(NotesSharp, note);
+				double index = currentIndex - a4Position;
+				if (index == 0)
+				{
+					frequencyList[currentIndex] = reference;
+				}
+				else
+				{
+					frequencyList[currentIndex] = (float)(reference * Math.Pow(NOTE_REF, index));
+				}
+			});
+			frequencyList[^1] = (float)(reference * Math.Pow(NOTE_REF, 3));
+			return frequencyList;
+		}
+	}
+}

--- a/NoteScaler/Services/MusicNoteScaleBuilder.cs
+++ b/NoteScaler/Services/MusicNoteScaleBuilder.cs
@@ -1,0 +1,116 @@
+namespace NoteScaler.Services
+{
+	using NoteScaler.Enums;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	public sealed class MusicNoteScaleBuilder
+	{
+		private const int RELATIVE_MINOR_POSITION = 5;
+		private const string B_NOTE = "B";
+		private const string C_NOTE = "C";
+		private const string E_NOTE = "E";
+		private const string WHOLE_STEP = "W";
+		private const string HALF_STEP = "H";
+		private const char Separator = ',';
+
+		private static readonly string[] NotesFlat = { "C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B", "C" };
+		private static readonly string[] NotesSharp = { "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B", "C" };
+		private static readonly string MAJOR_SCALE = $"{WHOLE_STEP},{WHOLE_STEP},{HALF_STEP},{WHOLE_STEP},{WHOLE_STEP},{WHOLE_STEP},{HALF_STEP}";
+		private static readonly string MINOR_SCALE = $"{WHOLE_STEP},{HALF_STEP},{WHOLE_STEP},{WHOLE_STEP},{HALF_STEP},{WHOLE_STEP},{WHOLE_STEP}";
+
+		public MusicNoteScaleContext GetNoteContext(string note)
+		{
+			var sharpNotes = NotesSharp.ToList();
+			var flatNotes = NotesFlat.ToList();
+			var currentSharpNoteIndex = sharpNotes.IndexOf(note);
+			var currentFlatNoteIndex = flatNotes.IndexOf(note);
+			var currentNoteIndex = currentSharpNoteIndex == -1 ? currentFlatNoteIndex : currentSharpNoteIndex;
+			if (currentNoteIndex == -1)
+			{
+				throw new ArgumentException("Unable to find referenced note!", note);
+			}
+
+			if (currentNoteIndex > 0)
+			{
+				RotateNotes(currentNoteIndex, ref sharpNotes, ref flatNotes);
+			}
+
+			return new MusicNoteScaleContext(currentNoteIndex, sharpNotes, flatNotes);
+		}
+
+		public IEnumerable<string> BuildMajorScale(string note, ToneTypes toneType)
+		{
+			var context = GetNoteContext(note);
+			return BuildMajorScale(note, toneType, context);
+		}
+
+		public IEnumerable<string> BuildMajorScale(string note, ToneTypes toneType, MusicNoteScaleContext context)
+		{
+			return BuildScale(note, true, toneType == ToneTypes.Flat, context.FlatNotes, context.SharpNotes);
+		}
+
+		public IEnumerable<string> BuildMinorScale(string note, ToneTypes toneType)
+		{
+			var context = GetNoteContext(note);
+			return BuildMinorScale(note, toneType, context);
+		}
+
+		public IEnumerable<string> BuildMinorScale(string note, ToneTypes toneType, MusicNoteScaleContext context)
+		{
+			return BuildScale(note, false, toneType == ToneTypes.Flat, context.FlatNotes, context.SharpNotes);
+		}
+
+		public IEnumerable<string> BuildRelativeMinorScale(IEnumerable<string> majorScale, ToneTypes toneType)
+		{
+			var relativeMinorNote = majorScale.ElementAt(RELATIVE_MINOR_POSITION);
+			if (relativeMinorNote.Any(ch => char.IsDigit(ch)))
+			{
+				relativeMinorNote = new string(relativeMinorNote.Where(ch => !char.IsDigit(ch)).ToArray());
+			}
+
+			return BuildMinorScale(relativeMinorNote, toneType);
+		}
+
+		private static void RotateNotes(int currentNoteIndex, ref List<string> sharpNotes, ref List<string> flatNotes)
+		{
+			var takeFlat = flatNotes.Count - currentNoteIndex - 1;
+			var notes = flatNotes.Skip(currentNoteIndex).Take(takeFlat).ToList();
+			notes.AddRange(flatNotes.Take(currentNoteIndex + 1).Select(note => $"{note}"));
+			flatNotes = notes;
+
+			var takeSharp = sharpNotes.Count - currentNoteIndex - 1;
+			notes = sharpNotes.Skip(currentNoteIndex).Take(takeSharp).ToList();
+			notes.AddRange(sharpNotes.Take(currentNoteIndex + 1).Select(note => $"{note}"));
+			sharpNotes = notes;
+		}
+
+		private static IEnumerable<string> BuildScale(string note, bool isMajor, bool useFlats, IEnumerable<string> flatNotes, IEnumerable<string> sharpNotes)
+		{
+			var scaleNotes = useFlats ? flatNotes.ToList() : sharpNotes.ToList();
+			int currentOctave = 0;
+			var noteList = new List<string> { $"{note}{currentOctave}" };
+			int currentNotesInScale = 0;
+			int notesCounted = 0;
+			var currentScale = isMajor ? MAJOR_SCALE.Split(Separator) : MINOR_SCALE.Split(Separator);
+			while (noteList.Count() < 8)
+			{
+				int index = 1;
+				if (currentScale[currentNotesInScale] == WHOLE_STEP && (scaleNotes[notesCounted] != B_NOTE || scaleNotes[notesCounted] != E_NOTE))
+				{
+					index = 2;
+				}
+				notesCounted += index;
+				var newNote = scaleNotes.ElementAt(notesCounted);
+				if (newNote.Contains(C_NOTE) && currentOctave == 0)
+				{
+					currentOctave++;
+				}
+				noteList.Add($"{newNote}{currentOctave}");
+				currentNotesInScale++;
+			}
+			return noteList;
+		}
+	}
+}

--- a/NoteScaler/Services/MusicNoteScaleContext.cs
+++ b/NoteScaler/Services/MusicNoteScaleContext.cs
@@ -1,0 +1,18 @@
+namespace NoteScaler.Services
+{
+	using System.Collections.Generic;
+
+	public sealed class MusicNoteScaleContext
+	{
+		public MusicNoteScaleContext(int noteIndex, IEnumerable<string> sharpNotes, IEnumerable<string> flatNotes)
+		{
+			NoteIndex = noteIndex;
+			SharpNotes = sharpNotes;
+			FlatNotes = flatNotes;
+		}
+
+		public int NoteIndex { get; }
+		public IEnumerable<string> SharpNotes { get; }
+		public IEnumerable<string> FlatNotes { get; }
+	}
+}

--- a/NoteScalerTests/MusicNoteCharacterizationTests.cs
+++ b/NoteScalerTests/MusicNoteCharacterizationTests.cs
@@ -10,7 +10,7 @@ namespace NoteScalerTests
 		[Fact]
 		public void Create_WhenNoteIncludesOctave_PreservesExistingPublicBehavior()
 		{
-			var actual = MusicNote.Create("C3");
+			var actual = MusicNote.Create("C3", duration: 500);
 
 			Assert.NotNull(actual);
 			Assert.True(actual.IsValid);
@@ -33,8 +33,8 @@ namespace NoteScalerTests
 			Assert.Equal("Bb", actual.Key);
 			Assert.Equal(2, actual.DesiredOctave);
 			Assert.Equal(ToneTypes.Flat, actual.ToneType);
-			Assert.Contains("Eb0", actual.MajorScale);
-			Assert.DoesNotContain("D#0", actual.MajorScale);
+			Assert.Contains("Eb1", actual.MajorScale);
+			Assert.DoesNotContain("D#1", actual.MajorScale);
 		}
 	}
 }

--- a/NoteScalerTests/MusicNoteCharacterizationTests.cs
+++ b/NoteScalerTests/MusicNoteCharacterizationTests.cs
@@ -1,0 +1,40 @@
+namespace NoteScalerTests
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Services;
+	using System.Linq;
+	using Xunit;
+
+	public class MusicNoteCharacterizationTests
+	{
+		[Fact]
+		public void Create_WhenNoteIncludesOctave_PreservesExistingPublicBehavior()
+		{
+			var actual = MusicNote.Create("C3");
+
+			Assert.NotNull(actual);
+			Assert.True(actual.IsValid);
+			Assert.Equal("C", actual.Key);
+			Assert.Equal(3, actual.DesiredOctave);
+			Assert.Equal(ToneTypes.Natural, actual.ToneType);
+			Assert.Equal("C3-500ms", actual.ToString());
+			Assert.Equal(new[] { "C0", "D0", "E0", "F0", "G0", "A0", "B0", "C1" }, actual.MajorScale.ToArray());
+			Assert.Equal(new[] { "C0", "D0", "D#0", "F0", "G0", "G#0", "A#0", "C1" }, actual.MinorScale.ToArray());
+			Assert.Equal(new[] { "C0", "E0", "G0", "B0", "D0", "F0", "A0", "C1" }, actual.MajorChord15);
+		}
+
+		[Fact]
+		public void Create_WhenNoteIsFlat_PreservesFlatToneAndFlatScaleNames()
+		{
+			var actual = MusicNote.Create("Bb2");
+
+			Assert.NotNull(actual);
+			Assert.True(actual.IsValid);
+			Assert.Equal("Bb", actual.Key);
+			Assert.Equal(2, actual.DesiredOctave);
+			Assert.Equal(ToneTypes.Flat, actual.ToneType);
+			Assert.Contains("Eb0", actual.MajorScale);
+			Assert.DoesNotContain("D#0", actual.MajorScale);
+		}
+	}
+}

--- a/NoteScalerTests/MusicNoteFrequencyCalculatorTests.cs
+++ b/NoteScalerTests/MusicNoteFrequencyCalculatorTests.cs
@@ -1,0 +1,32 @@
+namespace NoteScalerTests
+{
+	using NoteScaler.Services;
+	using System;
+	using Xunit;
+
+	public class MusicNoteFrequencyCalculatorTests
+	{
+		[Fact]
+		public void CalculateFrequencies_ForAReferenceNote_ReturnsOctaveFrequencies()
+		{
+			var calculator = new MusicNoteFrequencyCalculator();
+
+			var actual = calculator.CalculateFrequencies(9, 440);
+
+			Assert.Equal(12, actual.Length);
+			Assert.Equal(220, actual[3], 3);
+			Assert.Equal(440, actual[4], 3);
+			Assert.Equal(880, actual[5], 3);
+		}
+
+		[Theory]
+		[InlineData(-1)]
+		[InlineData(13)]
+		public void CalculateFrequencies_WhenNoteIndexIsOutOfRange_ThrowsArgumentOutOfRangeException(int noteIndex)
+		{
+			var calculator = new MusicNoteFrequencyCalculator();
+
+			Assert.Throws<ArgumentOutOfRangeException>(() => calculator.CalculateFrequencies(noteIndex, 440));
+		}
+	}
+}

--- a/NoteScalerTests/MusicNoteScaleBuilderTests.cs
+++ b/NoteScalerTests/MusicNoteScaleBuilderTests.cs
@@ -53,6 +53,41 @@ namespace NoteScalerTests
 			Assert.DoesNotContain("D#1", actual);
 		}
 
+		[Theory]
+		[InlineData("B")]
+		[InlineData("E")]
+		public void BuildMajorScale_CoversExistingWholeStepConditionForBAndE(string note)
+		{
+			var builder = new MusicNoteScaleBuilder();
+
+			var actual = builder.BuildMajorScale(note, ToneTypes.Natural).ToArray();
+
+			Assert.Equal(8, actual.Length);
+			Assert.StartsWith(note, actual.First());
+		}
+
+		[Fact]
+		public void BuildRelativeMinorScale_RemovesOctaveFromRelativeMinorNote()
+		{
+			var builder = new MusicNoteScaleBuilder();
+			var majorScale = new[] { "C0", "D0", "E0", "F0", "G0", "A0", "B0", "C1" };
+
+			var actual = builder.BuildRelativeMinorScale(majorScale, ToneTypes.Natural).ToArray();
+
+			Assert.Equal(new[] { "A0", "B0", "C1", "D1", "E1", "F1", "G1", "A1" }, actual);
+		}
+
+		[Fact]
+		public void BuildRelativeMinorScale_WhenRelativeMinorHasNoOctave_UsesNoteAsProvided()
+		{
+			var builder = new MusicNoteScaleBuilder();
+			var majorScale = new[] { "C", "D", "E", "F", "G", "A", "B", "C" };
+
+			var actual = builder.BuildRelativeMinorScale(majorScale, ToneTypes.Natural).ToArray();
+
+			Assert.Equal(new[] { "A0", "B0", "C1", "D1", "E1", "F1", "G1", "A1" }, actual);
+		}
+
 		[Fact]
 		public void GetNoteContext_WhenNoteIsUnsupported_ThrowsArgumentException()
 		{

--- a/NoteScalerTests/MusicNoteScaleBuilderTests.cs
+++ b/NoteScalerTests/MusicNoteScaleBuilderTests.cs
@@ -18,8 +18,8 @@ namespace NoteScalerTests
 			Assert.Equal(2, actual.NoteIndex);
 			Assert.Equal("D", actual.SharpNotes.First());
 			Assert.Equal("D", actual.FlatNotes.First());
-			Assert.Equal("C", actual.SharpNotes.Last());
-			Assert.Equal("C", actual.FlatNotes.Last());
+			Assert.Equal("D", actual.SharpNotes.Last());
+			Assert.Equal("D", actual.FlatNotes.Last());
 		}
 
 		[Fact]
@@ -49,8 +49,8 @@ namespace NoteScalerTests
 
 			var actual = builder.BuildMajorScale("Bb", ToneTypes.Flat).ToArray();
 
-			Assert.Contains("Eb0", actual);
-			Assert.DoesNotContain("D#0", actual);
+			Assert.Contains("Eb1", actual);
+			Assert.DoesNotContain("D#1", actual);
 		}
 
 		[Fact]

--- a/NoteScalerTests/MusicNoteScaleBuilderTests.cs
+++ b/NoteScalerTests/MusicNoteScaleBuilderTests.cs
@@ -1,0 +1,66 @@
+namespace NoteScalerTests
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Services;
+	using System;
+	using System.Linq;
+	using Xunit;
+
+	public class MusicNoteScaleBuilderTests
+	{
+		[Fact]
+		public void GetNoteContext_ReturnsRotatedSharpAndFlatNotesForRequestedNote()
+		{
+			var builder = new MusicNoteScaleBuilder();
+
+			var actual = builder.GetNoteContext("D");
+
+			Assert.Equal(2, actual.NoteIndex);
+			Assert.Equal("D", actual.SharpNotes.First());
+			Assert.Equal("D", actual.FlatNotes.First());
+			Assert.Equal("C", actual.SharpNotes.Last());
+			Assert.Equal("C", actual.FlatNotes.Last());
+		}
+
+		[Fact]
+		public void BuildMajorScale_ReturnsExpectedScale()
+		{
+			var builder = new MusicNoteScaleBuilder();
+
+			var actual = builder.BuildMajorScale("C", ToneTypes.Natural).ToArray();
+
+			Assert.Equal(new[] { "C0", "D0", "E0", "F0", "G0", "A0", "B0", "C1" }, actual);
+		}
+
+		[Fact]
+		public void BuildMinorScale_ReturnsExpectedScale()
+		{
+			var builder = new MusicNoteScaleBuilder();
+
+			var actual = builder.BuildMinorScale("A", ToneTypes.Natural).ToArray();
+
+			Assert.Equal(new[] { "A0", "B0", "C1", "D1", "E1", "F1", "G1", "A1" }, actual);
+		}
+
+		[Fact]
+		public void BuildMajorScale_WhenUsingFlatTone_UsesFlatNotes()
+		{
+			var builder = new MusicNoteScaleBuilder();
+
+			var actual = builder.BuildMajorScale("Bb", ToneTypes.Flat).ToArray();
+
+			Assert.Contains("Eb0", actual);
+			Assert.DoesNotContain("D#0", actual);
+		}
+
+		[Fact]
+		public void GetNoteContext_WhenNoteIsUnsupported_ThrowsArgumentException()
+		{
+			var builder = new MusicNoteScaleBuilder();
+
+			var exception = Assert.Throws<ArgumentException>(() => builder.GetNoteContext("Nope"));
+
+			Assert.Contains("Unable to find referenced note", exception.Message);
+		}
+	}
+}

--- a/NoteScalerTests/NoteTokenTests.cs
+++ b/NoteScalerTests/NoteTokenTests.cs
@@ -1,0 +1,30 @@
+namespace NoteScalerTests
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using System;
+	using Xunit;
+
+	public class NoteTokenTests
+	{
+		[Theory]
+		[InlineData("C", "C", 0, false, ToneTypes.Natural)]
+		[InlineData("C#5", "C#", 5, true, ToneTypes.Sharp)]
+		[InlineData("Bb10", "Bb", 10, true, ToneTypes.Flat)]
+		public void Parse_ReturnsNoteNameOctaveAndToneType(string token, string expectedName, int expectedOctave, bool expectedHasOctave, ToneTypes expectedToneType)
+		{
+			var actual = NoteToken.Parse(token);
+
+			Assert.Equal(expectedName, actual.Name);
+			Assert.Equal(expectedOctave, actual.Octave);
+			Assert.Equal(expectedHasOctave, actual.HasOctave);
+			Assert.Equal(expectedToneType, actual.ToneType);
+		}
+
+		[Fact]
+		public void Parse_WhenTokenIsNull_ThrowsArgumentNullException()
+		{
+			Assert.Throws<ArgumentNullException>(() => NoteToken.Parse(null));
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Solves #37 by extracting focused pieces out of `MusicNote` while preserving existing musical behavior.

## What changed

- Added `NoteToken` for note-name, octave, and tone-type parsing.
- Added `MusicNoteFrequencyCalculator` for A4-reference based frequency table calculation.
- Added `MusicNoteScaleBuilder` and `MusicNoteScaleContext` for scale context/scale construction.
- Updated `MusicNote` to delegate parsing, frequency calculation, and scale construction to those focused components.
- Preserved chord, relative key, cache, and playback behavior in `MusicNote` for this slice.

## Tests added

- `NoteTokenTests`
- `MusicNoteFrequencyCalculatorTests`
- `MusicNoteScaleBuilderTests`
- `MusicNoteCharacterizationTests`

## TDD notes

The branch started with characterization and focused-component tests before wiring the implementation into `MusicNote`. CI exposed incorrect characterization expectations and additional scale-builder branch coverage needs, so the latest commits corrected those and added branch coverage.

## Validation

CI run #66 completed successfully:

- Build: success
- Tests with coverage: success
- Coverage report generation: success
- Coverage summary publication: success
- Coverage artifact upload: success