### PR TITLE
Finish guitar tuning catalog refactor

### DIFF
--- a/NoteScaler/Models/TuningDefinition.cs
+++ b/NoteScaler/Models/TuningDefinition.cs
@@ -1,0 +1,38 @@
+namespace NoteScaler.Models
+{
+	using NoteScaler.Enums;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	public sealed class TuningDefinition
+	{
+		private readonly IReadOnlyList<string> openStringNotes;
+
+		public TuningDefinition(TuningScheme tuningScheme, IEnumerable<string> openStringNotes)
+		{
+			if (openStringNotes == null)
+			{
+				throw new ArgumentNullException(nameof(openStringNotes));
+			}
+
+			var notes = openStringNotes.ToArray();
+			if (notes.Length == 0)
+			{
+				throw new ArgumentException("A tuning definition must include at least one open string note.", nameof(openStringNotes));
+			}
+
+			if (notes.Any(string.IsNullOrWhiteSpace))
+			{
+				throw new ArgumentException("A tuning definition cannot contain empty open string notes.", nameof(openStringNotes));
+			}
+
+			TuningScheme = tuningScheme;
+			this.openStringNotes = Array.AsReadOnly(notes);
+		}
+
+		public TuningScheme TuningScheme { get; }
+
+		public IReadOnlyList<string> OpenStringNotes => openStringNotes;
+	}
+}

--- a/NoteScaler/Services/Guitar.cs
+++ b/NoteScaler/Services/Guitar.cs
@@ -9,22 +9,6 @@
 
 	public class Guitar : IStringInstrument
 	{
-		private static readonly IReadOnlyDictionary<TuningScheme, string[]> TuningDefinitions = new Dictionary<TuningScheme, string[]>
-		{
-			[TuningScheme.Standard] = new[] { "E4", "B3", "G3", "D3", "A2", "E2" },
-			[TuningScheme.DropC] = new[] { "D4", "A3", "F3", "C3", "G2", "C2" },
-			[TuningScheme.DropCSharp] = new[] { "D#4", "A#3", "F#3", "C#3", "G#2", "C#2" },
-			[TuningScheme.DropD] = new[] { "D4", "B3", "G3", "D3", "A2", "D2" },
-			[TuningScheme.OpenC] = new[] { "E4", "C3", "G3", "C3", "G2", "C2" },
-			[TuningScheme.OpenD] = new[] { "D4", "A3", "F#3", "D3", "A2", "D2" },
-			[TuningScheme.DropB] = new[] { "C#4", "G#3", "E3", "B2", "F#2", "B1" },
-			[TuningScheme.DStandard] = new[] { "D4", "A3", "F3", "C3", "G2", "D2" },
-			[TuningScheme.EbStandard] = new[] { "D#4", "A#3", "F#3", "C#3", "G#2", "D#2" },
-			[TuningScheme.CSharpStandard] = new[] { "C#4", "G#3", "E3", "B2", "F#2", "C#2" },
-			[TuningScheme.DADGAD] = new[] { "D4", "A3", "G3", "D3", "A2", "D2" },
-			[TuningScheme.OpenG] = new[] { "D4", "B3", "G3", "D3", "G2", "D2" }
-		};
-
 		/// <summary>
 		/// Copnstructs a Guitar!
 		/// </summary>
@@ -134,7 +118,8 @@
 
 		private void InitializeStrings()
 		{
-			Strings = TuningDefinitions[TuningScheme]
+			var tuningDefinition = GuitarTuningCatalog.GetDefinition(TuningScheme);
+			Strings = tuningDefinition.OpenStringNotes
 				.Select((note, index) => new GuitarString(index + 1, note, Frets))
 				.ToList();
 		}

--- a/NoteScaler/Services/GuitarTuningCatalog.cs
+++ b/NoteScaler/Services/GuitarTuningCatalog.cs
@@ -1,0 +1,39 @@
+namespace NoteScaler.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	public static class GuitarTuningCatalog
+	{
+		private static readonly IReadOnlyDictionary<TuningScheme, TuningDefinition> Definitions = new[]
+		{
+			new TuningDefinition(TuningScheme.Standard, new[] { "E4", "B3", "G3", "D3", "A2", "E2" }),
+			new TuningDefinition(TuningScheme.DropC, new[] { "D4", "A3", "F3", "C3", "G2", "C2" }),
+			new TuningDefinition(TuningScheme.DropCSharp, new[] { "D#4", "A#3", "F#3", "C#3", "G#2", "C#2" }),
+			new TuningDefinition(TuningScheme.DropD, new[] { "D4", "B3", "G3", "D3", "A2", "D2" }),
+			new TuningDefinition(TuningScheme.OpenC, new[] { "E4", "C3", "G3", "C3", "G2", "C2" }),
+			new TuningDefinition(TuningScheme.OpenD, new[] { "D4", "A3", "F#3", "D3", "A2", "D2" }),
+			new TuningDefinition(TuningScheme.DropB, new[] { "C#4", "G#3", "E3", "B2", "F#2", "B1" }),
+			new TuningDefinition(TuningScheme.DStandard, new[] { "D4", "A3", "F3", "C3", "G2", "D2" }),
+			new TuningDefinition(TuningScheme.EbStandard, new[] { "D#4", "A#3", "F#3", "C#3", "G#2", "D#2" }),
+			new TuningDefinition(TuningScheme.CSharpStandard, new[] { "C#4", "G#3", "E3", "B2", "F#2", "C#2" }),
+			new TuningDefinition(TuningScheme.DADGAD, new[] { "D4", "A3", "G3", "D3", "A2", "D2" }),
+			new TuningDefinition(TuningScheme.OpenG, new[] { "D4", "B3", "G3", "D3", "G2", "D2" })
+		}.ToDictionary(definition => definition.TuningScheme);
+
+		public static IReadOnlyCollection<TuningDefinition> SupportedTunings => Definitions.Values.ToArray();
+
+		public static TuningDefinition GetDefinition(TuningScheme tuningScheme)
+		{
+			if (Definitions.TryGetValue(tuningScheme, out var definition))
+			{
+				return definition;
+			}
+
+			throw new ArgumentException($"Unsupported tuning scheme: {tuningScheme}", nameof(tuningScheme));
+		}
+	}
+}

--- a/NoteScalerTests/Models/TuningDefinitionTests.cs
+++ b/NoteScalerTests/Models/TuningDefinitionTests.cs
@@ -1,0 +1,60 @@
+namespace NoteScalerTests.Models
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using System;
+	using System.Collections.Generic;
+	using Xunit;
+
+	public class TuningDefinitionTests
+	{
+		[Fact]
+		public void Constructor_RequiresOpenStringNotes()
+		{
+			var exception = Assert.Throws<ArgumentNullException>(() => new TuningDefinition(TuningScheme.Standard, null));
+
+			Assert.Equal("openStringNotes", exception.ParamName);
+		}
+
+		[Fact]
+		public void Constructor_RequiresAtLeastOneOpenStringNote()
+		{
+			var exception = Assert.Throws<ArgumentException>(() => new TuningDefinition(TuningScheme.Standard, Array.Empty<string>()));
+
+			Assert.Equal("openStringNotes", exception.ParamName);
+			Assert.Contains("at least one", exception.Message);
+		}
+
+		[Theory]
+		[InlineData("")]
+		[InlineData(" ")]
+		public void Constructor_RejectsEmptyOpenStringNotes(string invalidNote)
+		{
+			var exception = Assert.Throws<ArgumentException>(() => new TuningDefinition(TuningScheme.Standard, new[] { "E4", invalidNote }));
+
+			Assert.Equal("openStringNotes", exception.ParamName);
+			Assert.Contains("empty", exception.Message);
+		}
+
+		[Fact]
+		public void Constructor_CopiesOpenStringNotesIntoDefinition()
+		{
+			var notes = new[] { "E4", "B3", "G3", "D3", "A2", "E2" };
+
+			var definition = new TuningDefinition(TuningScheme.Standard, notes);
+			notes[0] = "D4";
+
+			Assert.Equal(TuningScheme.Standard, definition.TuningScheme);
+			Assert.Equal(new[] { "E4", "B3", "G3", "D3", "A2", "E2" }, definition.OpenStringNotes);
+		}
+
+		[Fact]
+		public void OpenStringNotes_CannotBeMutatedThroughExposedCollection()
+		{
+			var definition = new TuningDefinition(TuningScheme.Standard, new[] { "E4", "B3" });
+			var exposedNotes = Assert.IsAssignableFrom<IList<string>>(definition.OpenStringNotes);
+
+			Assert.Throws<NotSupportedException>(() => exposedNotes[0] = "D4");
+		}
+	}
+}

--- a/NoteScalerTests/Services/GuitarTuningCatalogTests.cs
+++ b/NoteScalerTests/Services/GuitarTuningCatalogTests.cs
@@ -53,7 +53,7 @@ namespace NoteScalerTests.Services
 			var supportedTunings = GuitarTuningCatalog.SupportedTunings.ToArray();
 
 			Assert.All(supportedTunings, definition => Assert.NotEmpty(definition.OpenStringNotes));
-			Assert.All(supportedTunings, definition => Assert.All(definition.OpenStringNotes, Assert.False));
+			Assert.All(supportedTunings, definition => Assert.All(definition.OpenStringNotes, note => Assert.False(string.IsNullOrWhiteSpace(note))));
 		}
 
 		[Fact]

--- a/NoteScalerTests/Services/GuitarTuningCatalogTests.cs
+++ b/NoteScalerTests/Services/GuitarTuningCatalogTests.cs
@@ -1,0 +1,68 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Services;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using Xunit;
+
+	public class GuitarTuningCatalogTests
+	{
+		public static IEnumerable<object[]> ExpectedTuningDefinitions => new[]
+		{
+			new object[] { TuningScheme.Standard, new[] { "E4", "B3", "G3", "D3", "A2", "E2" } },
+			new object[] { TuningScheme.DropC, new[] { "D4", "A3", "F3", "C3", "G2", "C2" } },
+			new object[] { TuningScheme.DropCSharp, new[] { "D#4", "A#3", "F#3", "C#3", "G#2", "C#2" } },
+			new object[] { TuningScheme.DropD, new[] { "D4", "B3", "G3", "D3", "A2", "D2" } },
+			new object[] { TuningScheme.OpenC, new[] { "E4", "C3", "G3", "C3", "G2", "C2" } },
+			new object[] { TuningScheme.OpenD, new[] { "D4", "A3", "F#3", "D3", "A2", "D2" } },
+			new object[] { TuningScheme.DropB, new[] { "C#4", "G#3", "E3", "B2", "F#2", "B1" } },
+			new object[] { TuningScheme.DStandard, new[] { "D4", "A3", "F3", "C3", "G2", "D2" } },
+			new object[] { TuningScheme.EbStandard, new[] { "D#4", "A#3", "F#3", "C#3", "G#2", "D#2" } },
+			new object[] { TuningScheme.CSharpStandard, new[] { "C#4", "G#3", "E3", "B2", "F#2", "C#2" } },
+			new object[] { TuningScheme.DADGAD, new[] { "D4", "A3", "G3", "D3", "A2", "D2" } },
+			new object[] { TuningScheme.OpenG, new[] { "D4", "B3", "G3", "D3", "G2", "D2" } }
+		};
+
+		[Theory]
+		[MemberData(nameof(ExpectedTuningDefinitions))]
+		public void GetDefinition_ReturnsExpectedOpenStringNotes(TuningScheme tuningScheme, string[] expectedOpenStringNotes)
+		{
+			var definition = GuitarTuningCatalog.GetDefinition(tuningScheme);
+
+			Assert.Equal(tuningScheme, definition.TuningScheme);
+			Assert.Equal(expectedOpenStringNotes, definition.OpenStringNotes);
+		}
+
+		[Fact]
+		public void SupportedTunings_ContainsEveryTuningScheme()
+		{
+			var expectedTunings = Enum.GetValues<TuningScheme>().OrderBy(tuningScheme => tuningScheme).ToArray();
+			var actualTunings = GuitarTuningCatalog.SupportedTunings
+				.Select(definition => definition.TuningScheme)
+				.OrderBy(tuningScheme => tuningScheme)
+				.ToArray();
+
+			Assert.Equal(expectedTunings, actualTunings);
+		}
+
+		[Fact]
+		public void SupportedTunings_ReturnsDefinitionsWithOpenStringData()
+		{
+			var supportedTunings = GuitarTuningCatalog.SupportedTunings.ToArray();
+
+			Assert.All(supportedTunings, definition => Assert.NotEmpty(definition.OpenStringNotes));
+			Assert.All(supportedTunings, definition => Assert.All(definition.OpenStringNotes, Assert.False));
+		}
+
+		[Fact]
+		public void GetDefinition_WhenTuningSchemeIsUnsupported_ThrowsControlledException()
+		{
+			var exception = Assert.Throws<ArgumentException>(() => GuitarTuningCatalog.GetDefinition((TuningScheme)999));
+
+			Assert.Equal("tuningScheme", exception.ParamName);
+			Assert.Contains("Unsupported tuning scheme", exception.Message);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Solves #39 by finishing the tuning-data refactor after the previous switch-removal PR.

## What changed

- Added `TuningDefinition` as the data model for a tuning.
- Added `GuitarTuningCatalog` as the focused catalog for supported tuning definitions.
- Updated `Guitar` so construction logic consumes catalog data instead of owning tuning definitions.
- Added direct tests for tuning definitions and the catalog.
- Preserved the existing supported tuning open-string notes:
  - Standard
  - DropC
  - DropCSharp
  - DropD
  - OpenC
  - OpenD
  - DropB
  - DStandard
  - EbStandard
  - CSharpStandard
  - DADGAD
  - OpenG

## TDD notes

This slice adds direct tests around the tuning definition model and catalog so tuning data can be verified independently of `Guitar` construction. `Guitar` remains covered by the existing open-string characterization tests.

## Validation

- Local test execution was not available in this environment because the .NET SDK is not installed here.
- CI should run the full build/test/coverage flow on the pull request.

No merge to `master`. Scott will review and merge if approved.