### PR TITLE
Support dynamic string instrument definitions

### DIFF
--- a/NoteScaler/Config/NoteScalerOptions.cs
+++ b/NoteScaler/Config/NoteScalerOptions.cs
@@ -34,5 +34,10 @@
 		[Option('t', "tab", Default = null, HelpText = "Name of the tab file to play from the Tabs directory.")]
 		public string Tab { get; set; }
 
+		[Option("string-instruments", Default = null, HelpText = "Path to a JSON file that defines custom string instruments for tab playback.")]
+		public string StringInstruments { get; set; }
+
+		[Option("string-instrument", Default = null, HelpText = "Name of the custom string instrument to use from --string-instruments.")]
+		public string StringInstrument { get; set; }
 	}
 }

--- a/NoteScaler/Instruments/custom-instruments.sample.json
+++ b/NoteScaler/Instruments/custom-instruments.sample.json
@@ -1,0 +1,33 @@
+{
+  "instruments": [
+    {
+      "name": "Six String Standard",
+      "strings": 6,
+      "frets": 24,
+      "capo": 0,
+      "openStrings": [
+        { "number": 1, "note": "E4" },
+        { "number": 2, "note": "B3" },
+        { "number": 3, "note": "G3" },
+        { "number": 4, "note": "D3" },
+        { "number": 5, "note": "A2" },
+        { "number": 6, "note": "E2" }
+      ]
+    },
+    {
+      "name": "Seven String Drop A",
+      "strings": 7,
+      "frets": 24,
+      "capo": 0,
+      "openStrings": [
+        { "number": 1, "note": "E4" },
+        { "number": 2, "note": "B3" },
+        { "number": 3, "note": "G3" },
+        { "number": 4, "note": "D3" },
+        { "number": 5, "note": "A2" },
+        { "number": 6, "note": "E2" },
+        { "number": 7, "note": "A1" }
+      ]
+    }
+  ]
+}

--- a/NoteScaler/Interfaces/IStringInstrument.cs
+++ b/NoteScaler/Interfaces/IStringInstrument.cs
@@ -7,9 +7,19 @@
 	public interface IStringInstrument
 	{
 		/// <summary>
+		/// Human-readable instrument name.
+		/// </summary>
+		string Name { get; }
+
+		/// <summary>
 		/// The number of Frets 
 		/// </summary>
 		int Frets { get; }
+
+		/// <summary>
+		/// Capo location, measured in frets from the nut.
+		/// </summary>
+		int Capo { get; }
 
 		/// <summary>
 		/// Instrument strings

--- a/NoteScaler/Models/StringInstrumentDefinition.cs
+++ b/NoteScaler/Models/StringInstrumentDefinition.cs
@@ -1,0 +1,33 @@
+namespace NoteScaler.Models
+{
+	using Newtonsoft.Json;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	public sealed class StringInstrumentDefinition
+	{
+		[JsonProperty("name", Required = Required.Always)]
+		public string Name { get; set; }
+
+		[JsonProperty("strings", Required = Required.Always)]
+		public int NumberOfStrings { get; set; }
+
+		[JsonProperty("frets", Required = Required.Always)]
+		public int Frets { get; set; }
+
+		[JsonProperty("capo")]
+		public int? Capo { get; set; }
+
+		[JsonProperty("openStrings", Required = Required.Always)]
+		public IEnumerable<StringInstrumentStringDefinition> OpenStrings { get; set; }
+
+		public int EffectiveCapo => Capo.GetValueOrDefault();
+
+		public IEnumerable<string> GetOpenStringNotesByStringNumber()
+		{
+			return OpenStrings
+				.OrderBy(stringDefinition => stringDefinition.Number)
+				.Select(stringDefinition => stringDefinition.Note);
+		}
+	}
+}

--- a/NoteScaler/Models/StringInstrumentDefinitionDocument.cs
+++ b/NoteScaler/Models/StringInstrumentDefinitionDocument.cs
@@ -1,0 +1,11 @@
+namespace NoteScaler.Models
+{
+	using Newtonsoft.Json;
+	using System.Collections.Generic;
+
+	public sealed class StringInstrumentDefinitionDocument
+	{
+		[JsonProperty("instruments", Required = Required.Always)]
+		public IEnumerable<StringInstrumentDefinition> Instruments { get; set; }
+	}
+}

--- a/NoteScaler/Models/StringInstrumentDefinitionLoadResult.cs
+++ b/NoteScaler/Models/StringInstrumentDefinitionLoadResult.cs
@@ -1,0 +1,30 @@
+namespace NoteScaler.Models
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	public sealed class StringInstrumentDefinitionLoadResult
+	{
+		private StringInstrumentDefinitionLoadResult(bool success, string error, IEnumerable<StringInstrumentDefinition> instruments)
+		{
+			Success = success;
+			Error = error;
+			Instruments = Array.AsReadOnly((instruments ?? Enumerable.Empty<StringInstrumentDefinition>()).ToArray());
+		}
+
+		public bool Success { get; }
+		public string Error { get; }
+		public IReadOnlyCollection<StringInstrumentDefinition> Instruments { get; }
+
+		public static StringInstrumentDefinitionLoadResult Loaded(IEnumerable<StringInstrumentDefinition> instruments)
+		{
+			return new StringInstrumentDefinitionLoadResult(true, null, instruments);
+		}
+
+		public static StringInstrumentDefinitionLoadResult NotLoaded(string error)
+		{
+			return new StringInstrumentDefinitionLoadResult(false, error, null);
+		}
+	}
+}

--- a/NoteScaler/Models/StringInstrumentStringDefinition.cs
+++ b/NoteScaler/Models/StringInstrumentStringDefinition.cs
@@ -1,0 +1,13 @@
+namespace NoteScaler.Models
+{
+	using Newtonsoft.Json;
+
+	public sealed class StringInstrumentStringDefinition
+	{
+		[JsonProperty("number", Required = Required.Always)]
+		public int Number { get; set; }
+
+		[JsonProperty("note", Required = Required.Always)]
+		public string Note { get; set; }
+	}
+}

--- a/NoteScaler/Program.cs
+++ b/NoteScaler/Program.cs
@@ -23,6 +23,7 @@
 			services.AddSingleton<IConsoleOutputService, ConsoleOutputService>();
 			services.AddSingleton<IPlayerFactory, SignalNotePlayerFactory>();
 			services.AddSingleton<IStringInstrumentFactory, StringInstrumentFactory>();
+			services.AddSingleton<IStringInstrumentDefinitionLoader, StringInstrumentDefinitionLoader>();
 			services.AddSingleton<IMusicNoteCache, MusicNoteCache>();
 			services.AddSingleton<MusicNoteScaleBuilder>();
 			services.AddSingleton<MusicNoteFrequencyCalculator>();

--- a/NoteScaler/Services/Guitar.cs
+++ b/NoteScaler/Services/Guitar.cs
@@ -9,6 +9,8 @@
 
 	public class Guitar : IStringInstrument
 	{
+		private readonly bool isDefinitionBased;
+
 		/// <summary>
 		/// Copnstructs a Guitar!
 		/// </summary>
@@ -17,14 +19,35 @@
 		public Guitar(TuningScheme scheme = TuningScheme.Standard, int numberofFrets = 24)
 		{
 			TuningScheme = scheme;
+			Name = scheme.ToString();
 			Frets = numberofFrets;
-			InitializeStrings();
+			Capo = 0;
+			InitializeStrings(GuitarTuningCatalog.GetDefinition(TuningScheme).OpenStringNotes);
 		}
 
+		public Guitar(StringInstrumentDefinition definition)
+		{
+			if (definition == null)
+			{
+				throw new ArgumentNullException(nameof(definition));
+			}
+
+			TuningScheme = TuningScheme.Standard;
+			Name = definition.Name;
+			Frets = definition.Frets;
+			Capo = definition.EffectiveCapo;
+			isDefinitionBased = true;
+			InitializeStrings(definition.GetOpenStringNotesByStringNumber());
+		}
+
+		/// <inheritdoc/>
+		public string Name { get; }
 		/// <inheritdoc/>
 		public TuningScheme TuningScheme { get; }
 		/// <inheritdoc/>
 		public int Frets { get; }
+		/// <inheritdoc/>
+		public int Capo { get; }
 		/// <inheritdoc/>
 		public IEnumerable<IInstrumentString> Strings { get; protected set; }
 		/// <inheritdoc/>
@@ -113,15 +136,29 @@
 		/// <returns></returns>
 		public override string ToString()
 		{
+			if (isDefinitionBased)
+			{
+				return $"String instrument {Name}. Capo {Capo}. Strings {string.Join('|', Strings.Reverse().Select(s => s.Tuning))}";
+			}
+
 			return $"Guitar tuned to {TuningScheme}. Strings {string.Join('|', Strings.Reverse().Select(s => s.Tuning))}";
 		}
 
-		private void InitializeStrings()
+		private void InitializeStrings(IEnumerable<string> openStringNotes)
 		{
-			var tuningDefinition = GuitarTuningCatalog.GetDefinition(TuningScheme);
-			Strings = tuningDefinition.OpenStringNotes
-				.Select((note, index) => new GuitarString(index + 1, note, Frets))
+			Strings = openStringNotes
+				.Select((note, index) => new GuitarString(index + 1, GetSoundingOpenStringNote(note), Frets))
 				.ToList();
+		}
+
+		private string GetSoundingOpenStringNote(string note)
+		{
+			if (Capo == 0)
+			{
+				return note;
+			}
+
+			return PitchIndex.Default.GetNoteAbove(note, Capo);
 		}
 	}
 }

--- a/NoteScaler/Services/Interfaces/IStringInstrumentDefinitionLoader.cs
+++ b/NoteScaler/Services/Interfaces/IStringInstrumentDefinitionLoader.cs
@@ -1,0 +1,9 @@
+namespace NoteScaler.Services.Interfaces
+{
+	using NoteScaler.Models;
+
+	public interface IStringInstrumentDefinitionLoader
+	{
+		StringInstrumentDefinitionLoadResult Load(string path);
+	}
+}

--- a/NoteScaler/Services/Interfaces/IStringInstrumentFactory.cs
+++ b/NoteScaler/Services/Interfaces/IStringInstrumentFactory.cs
@@ -2,9 +2,11 @@
 {
 	using NoteScaler.Enums;
 	using NoteScaler.Interfaces;
+	using NoteScaler.Models;
 
 	public interface IStringInstrumentFactory
 	{
 		IStringInstrument Create(TuningScheme tuningScheme, int numberOfFrets);
+		IStringInstrument Create(StringInstrumentDefinition definition);
 	}
 }

--- a/NoteScaler/Services/NoteScalerRunner.cs
+++ b/NoteScaler/Services/NoteScalerRunner.cs
@@ -20,17 +20,29 @@ namespace NoteScaler.Services
 		private readonly IPlayableSequenceFactory playableSequenceFactory;
 		private readonly IStringInstrumentFactory stringInstrumentFactory;
 		private readonly IConsoleOutputService consoleOutputService;
+		private readonly IStringInstrumentDefinitionLoader stringInstrumentDefinitionLoader;
 
 		public NoteScalerRunner(
 			ICommandLineOptionsService commandLineOptionsService,
 			IPlayableSequenceFactory playableSequenceFactory,
 			IStringInstrumentFactory stringInstrumentFactory,
 			IConsoleOutputService consoleOutputService)
+			: this(commandLineOptionsService, playableSequenceFactory, stringInstrumentFactory, consoleOutputService, new StringInstrumentDefinitionLoader())
+		{
+		}
+
+		public NoteScalerRunner(
+			ICommandLineOptionsService commandLineOptionsService,
+			IPlayableSequenceFactory playableSequenceFactory,
+			IStringInstrumentFactory stringInstrumentFactory,
+			IConsoleOutputService consoleOutputService,
+			IStringInstrumentDefinitionLoader stringInstrumentDefinitionLoader)
 		{
 			this.commandLineOptionsService = commandLineOptionsService;
 			this.playableSequenceFactory = playableSequenceFactory;
 			this.stringInstrumentFactory = stringInstrumentFactory;
 			this.consoleOutputService = consoleOutputService;
+			this.stringInstrumentDefinitionLoader = stringInstrumentDefinitionLoader;
 		}
 
 		public int Run(string[] args)
@@ -53,7 +65,7 @@ namespace NoteScaler.Services
 				playableSequence.PlayableSequenceEvent += PlayableSequence_PlayableSequenceEvent;
 
 				PlayNoteAsRequired(options.Note, options.Octave.GetValueOrDefault(), a4Reference, playableSequence);
-				PlayTabAsRequired(tabName, playableSequence);
+				PlayTabAsRequired(options, tabName, playableSequence);
 				PlaySongAsRequired(key, fileName, playableSequence);
 			}
 			finally
@@ -182,7 +194,7 @@ namespace NoteScaler.Services
 			}
 		}
 
-		private void PlayTabAsRequired(string tabName, PlayableSequence playableSequence)
+		private void PlayTabAsRequired(NoteScalerOptions options, string tabName, PlayableSequence playableSequence)
 		{
 			if (!string.IsNullOrEmpty(tabName))
 			{
@@ -194,13 +206,64 @@ namespace NoteScaler.Services
 				else
 				{
 					tabs.FixUp();
-					var guitar = stringInstrumentFactory.Create(tabs.Tuning, 21);
-					playableSequence.ConvertTabsToNoteSequence(guitar, tabs);
+					var stringInstrument = CreateStringInstrumentForTab(options, tabs);
+					if (stringInstrument == null)
+					{
+						return;
+					}
+
+					playableSequence.ConvertTabsToNoteSequence(stringInstrument, tabs);
 					playableSequence.Repeat = tabs.Repeat;
 					playableSequence.Prepare();
 					playableSequence.Play();
 				}
 			}
+		}
+
+		private IStringInstrument CreateStringInstrumentForTab(NoteScalerOptions options, Tablature tabs)
+		{
+			if (string.IsNullOrWhiteSpace(options.StringInstruments))
+			{
+				return stringInstrumentFactory.Create(tabs.Tuning, 21);
+			}
+
+			var loadResult = stringInstrumentDefinitionLoader.Load(options.StringInstruments);
+			if (!loadResult.Success)
+			{
+				consoleOutputService.WriteMessage(loadResult.Error, ConsoleColor.Red);
+				return null;
+			}
+
+			var definition = SelectStringInstrumentDefinition(loadResult.Instruments, options.StringInstrument);
+			if (definition == null)
+			{
+				return null;
+			}
+
+			consoleOutputService.WriteMessage($"Using string instrument: {definition.Name}");
+			return stringInstrumentFactory.Create(definition);
+		}
+
+		private StringInstrumentDefinition SelectStringInstrumentDefinition(IReadOnlyCollection<StringInstrumentDefinition> definitions, string requestedName)
+		{
+			if (!string.IsNullOrWhiteSpace(requestedName))
+			{
+				var requestedDefinition = definitions.SingleOrDefault(definition => definition.Name.Equals(requestedName, StringComparison.InvariantCultureIgnoreCase));
+				if (requestedDefinition == null)
+				{
+					consoleOutputService.WriteMessage($"String instrument not found: {requestedName}", ConsoleColor.Red);
+				}
+
+				return requestedDefinition;
+			}
+
+			if (definitions.Count == 1)
+			{
+				return definitions.Single();
+			}
+
+			consoleOutputService.WriteMessage("Multiple string instruments are available. Use --string-instrument to choose one.", ConsoleColor.Red);
+			return null;
 		}
 
 		private SongKey GetTheSongByKeyAsRequired(string key, Song song)

--- a/NoteScaler/Services/StringInstrumentDefinitionLoader.cs
+++ b/NoteScaler/Services/StringInstrumentDefinitionLoader.cs
@@ -1,0 +1,148 @@
+namespace NoteScaler.Services
+{
+	using Newtonsoft.Json;
+	using NoteScaler.Models;
+	using NoteScaler.Services.Interfaces;
+	using System;
+	using System.Collections.Generic;
+	using System.IO;
+	using System.Linq;
+
+	public sealed class StringInstrumentDefinitionLoader : IStringInstrumentDefinitionLoader
+	{
+		public StringInstrumentDefinitionLoadResult Load(string path)
+		{
+			if (string.IsNullOrWhiteSpace(path))
+			{
+				return StringInstrumentDefinitionLoadResult.NotLoaded("String instrument definition path is required.");
+			}
+
+			if (!File.Exists(path))
+			{
+				return StringInstrumentDefinitionLoadResult.NotLoaded($"String instrument definition file not found: {path}");
+			}
+
+			try
+			{
+				var document = JsonConvert.DeserializeObject<StringInstrumentDefinitionDocument>(File.ReadAllText(path));
+				var validationError = Validate(document);
+				if (!string.IsNullOrEmpty(validationError))
+				{
+					return StringInstrumentDefinitionLoadResult.NotLoaded(validationError);
+				}
+
+				return StringInstrumentDefinitionLoadResult.Loaded(document.Instruments.ToArray());
+			}
+			catch (Exception ex)
+			{
+				return StringInstrumentDefinitionLoadResult.NotLoaded($"Unable to load string instrument definitions from {path}: {ex.Message}");
+			}
+		}
+
+		private static string Validate(StringInstrumentDefinitionDocument document)
+		{
+			var instruments = document?.Instruments?.ToArray();
+			if (instruments == null || instruments.Length == 0)
+			{
+				return "String instrument definition file must contain at least one instrument.";
+			}
+
+			var duplicateName = instruments
+				.Where(instrument => !string.IsNullOrWhiteSpace(instrument.Name))
+				.GroupBy(instrument => instrument.Name, StringComparer.InvariantCultureIgnoreCase)
+				.FirstOrDefault(group => group.Count() > 1);
+			if (duplicateName != null)
+			{
+				return $"String instrument name must be unique: {duplicateName.Key}.";
+			}
+
+			foreach (var instrument in instruments)
+			{
+				var validationError = ValidateInstrument(instrument);
+				if (!string.IsNullOrEmpty(validationError))
+				{
+					return validationError;
+				}
+			}
+
+			return null;
+		}
+
+		private static string ValidateInstrument(StringInstrumentDefinition instrument)
+		{
+			if (instrument == null)
+			{
+				return "String instrument definition cannot be null.";
+			}
+
+			if (string.IsNullOrWhiteSpace(instrument.Name))
+			{
+				return "String instrument name is required.";
+			}
+
+			if (instrument.NumberOfStrings <= 0)
+			{
+				return $"String instrument {instrument.Name} must define at least one string.";
+			}
+
+			if (instrument.Frets <= 0)
+			{
+				return $"String instrument {instrument.Name} must define at least one fret.";
+			}
+
+			if (instrument.EffectiveCapo < 0 || instrument.EffectiveCapo > instrument.Frets)
+			{
+				return $"String instrument {instrument.Name} has invalid capo location {instrument.EffectiveCapo}.";
+			}
+
+			var strings = instrument.OpenStrings?.ToArray();
+			if (strings == null || strings.Length != instrument.NumberOfStrings)
+			{
+				return $"String instrument {instrument.Name} must define exactly {instrument.NumberOfStrings} open strings.";
+			}
+
+			var duplicateString = strings
+				.GroupBy(stringDefinition => stringDefinition.Number)
+				.FirstOrDefault(group => group.Count() > 1);
+			if (duplicateString != null)
+			{
+				return $"String instrument {instrument.Name} has duplicate string number {duplicateString.Key}.";
+			}
+
+			foreach (var stringDefinition in strings)
+			{
+				var validationError = ValidateString(instrument, stringDefinition);
+				if (!string.IsNullOrEmpty(validationError))
+				{
+					return validationError;
+				}
+			}
+
+			return null;
+		}
+
+		private static string ValidateString(StringInstrumentDefinition instrument, StringInstrumentStringDefinition stringDefinition)
+		{
+			if (stringDefinition.Number < 1 || stringDefinition.Number > instrument.NumberOfStrings)
+			{
+				return $"String instrument {instrument.Name} has invalid string number {stringDefinition.Number}.";
+			}
+
+			if (!PitchIndex.Default.Contains(stringDefinition.Note))
+			{
+				return $"String instrument {instrument.Name} string {stringDefinition.Number} has unsupported note {stringDefinition.Note}.";
+			}
+
+			try
+			{
+				PitchIndex.Default.GetNoteAbove(stringDefinition.Note, instrument.EffectiveCapo);
+			}
+			catch (ArgumentOutOfRangeException)
+			{
+				return $"String instrument {instrument.Name} string {stringDefinition.Number} capo note is outside the supported pitch range.";
+			}
+
+			return null;
+		}
+	}
+}

--- a/NoteScaler/Services/StringInstrumentDefinitionLoader.cs
+++ b/NoteScaler/Services/StringInstrumentDefinitionLoader.cs
@@ -4,7 +4,6 @@ namespace NoteScaler.Services
 	using NoteScaler.Models;
 	using NoteScaler.Services.Interfaces;
 	using System;
-	using System.Collections.Generic;
 	using System.IO;
 	using System.Linq;
 
@@ -48,7 +47,7 @@ namespace NoteScaler.Services
 			}
 
 			var duplicateName = instruments
-				.Where(instrument => !string.IsNullOrWhiteSpace(instrument.Name))
+				.Where(instrument => instrument != null && !string.IsNullOrWhiteSpace(instrument.Name))
 				.GroupBy(instrument => instrument.Name, StringComparer.InvariantCultureIgnoreCase)
 				.FirstOrDefault(group => group.Count() > 1);
 			if (duplicateName != null)
@@ -99,6 +98,11 @@ namespace NoteScaler.Services
 			if (strings == null || strings.Length != instrument.NumberOfStrings)
 			{
 				return $"String instrument {instrument.Name} must define exactly {instrument.NumberOfStrings} open strings.";
+			}
+
+			if (strings.Any(stringDefinition => stringDefinition == null))
+			{
+				return $"String instrument {instrument.Name} has a null string definition.";
 			}
 
 			var duplicateString = strings

--- a/NoteScaler/Services/StringInstrumentFactory.cs
+++ b/NoteScaler/Services/StringInstrumentFactory.cs
@@ -2,6 +2,7 @@ namespace NoteScaler.Services
 {
 	using NoteScaler.Enums;
 	using NoteScaler.Interfaces;
+	using NoteScaler.Models;
 	using NoteScaler.Services.Interfaces;
 
 	public sealed class StringInstrumentFactory : IStringInstrumentFactory
@@ -9,6 +10,11 @@ namespace NoteScaler.Services
 		public IStringInstrument Create(TuningScheme tuningScheme, int numberOfFrets)
 		{
 			return new Guitar(tuningScheme, numberOfFrets);
+		}
+
+		public IStringInstrument Create(StringInstrumentDefinition definition)
+		{
+			return new Guitar(definition);
 		}
 	}
 }

--- a/NoteScalerTests/Models/UnusedStringInstrumentFactory.cs
+++ b/NoteScalerTests/Models/UnusedStringInstrumentFactory.cs
@@ -2,12 +2,18 @@ namespace NoteScalerTests.Models
 {
 	using NoteScaler.Enums;
 	using NoteScaler.Interfaces;
+	using NoteScaler.Models;
 	using NoteScaler.Services.Interfaces;
 	using System;
 
 	public sealed class UnusedStringInstrumentFactory : IStringInstrumentFactory
 	{
 		public IStringInstrument Create(TuningScheme tuningScheme, int numberOfFrets)
+		{
+			throw new InvalidOperationException($"The string instrument factory should not be used by {nameof(UnusedStringInstrumentFactory)}.");
+		}
+
+		public IStringInstrument Create(StringInstrumentDefinition definition)
 		{
 			throw new InvalidOperationException($"The string instrument factory should not be used by {nameof(UnusedStringInstrumentFactory)}.");
 		}

--- a/NoteScalerTests/Services/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/Services/NoteScalerRunnerTests.cs
@@ -127,6 +127,32 @@ namespace NoteScalerTests.Services
 			Assert.True(harness.Player.PlayCount > 0);
 		}
 
+		[Fact]
+		public void Run_LoadsAndPlaysTabFileWithCustomStringInstrument()
+		{
+			CreateSevenStringTabFile("runner-seven-string-tab");
+			var instrumentDefinitionsPath = CreateSevenStringInstrumentDefinitionFile("custom-instruments.json");
+			var harness = CreateHarness();
+
+			harness.Runner.Run(new[] { "--tab", "runner-seven-string-tab", "--string-instruments", instrumentDefinitionsPath, "--string-instrument", "Seven String Drop A" });
+
+			Assert.Contains(harness.Console.Messages, message => message.Contains("Using string instrument: Seven String Drop A"));
+			Assert.NotNull(harness.Factory.CreatedSequence);
+			Assert.True(harness.Player.PlayCount > 0);
+		}
+
+		[Fact]
+		public void Run_WhenMultipleCustomStringInstrumentsAreAvailableWithoutSelection_WritesError()
+		{
+			CreateTabFile("runner-tab");
+			var instrumentDefinitionsPath = CreateMultipleInstrumentDefinitionFile("multiple-instruments.json");
+			var harness = CreateHarness();
+
+			harness.Runner.Run(new[] { "--tab", "runner-tab", "--string-instruments", instrumentDefinitionsPath });
+
+			Assert.Contains(harness.Console.Messages, message => message.Contains("Use --string-instrument to choose one"));
+		}
+
 		public void Dispose()
 		{
 			Environment.CurrentDirectory = originalCurrentDirectory;
@@ -172,6 +198,73 @@ namespace NoteScalerTests.Services
 		{
 			Directory.CreateDirectory("Tabs");
 			File.WriteAllText(Path.Combine("Tabs", $"{fileName}.json"), "{\"name\":\"Tab\",\"speed\":1000,\"tab\":\"1-0\",\"tuning\":\"Standard\",\"repeat\":1,\"default\":\"Lead\",\"versions\":[{\"name\":\"Lead\",\"speed\":0,\"tab\":\"1-0,2-1\",\"tuning\":\"Standard\"}]}");
+		}
+
+		private static void CreateSevenStringTabFile(string fileName)
+		{
+			Directory.CreateDirectory("Tabs");
+			File.WriteAllText(Path.Combine("Tabs", $"{fileName}.json"), "{\"name\":\"Seven String Tab\",\"speed\":1000,\"strings\":7,\"tab\":\"7-0\",\"tuning\":\"Standard\",\"repeat\":1,\"default\":\"Lead\",\"versions\":[{\"name\":\"Lead\",\"speed\":0,\"tab\":\"7-0,1-0\",\"tuning\":\"Standard\"}]}");
+		}
+
+		private static string CreateSevenStringInstrumentDefinitionFile(string fileName)
+		{
+			var path = Path.Combine(Environment.CurrentDirectory, fileName);
+			File.WriteAllText(path, @"{
+				""instruments"": [
+					{
+						""name"": ""Seven String Drop A"",
+						""strings"": 7,
+						""frets"": 24,
+						""openStrings"": [
+							{ ""number"": 1, ""note"": ""E4"" },
+							{ ""number"": 2, ""note"": ""B3"" },
+							{ ""number"": 3, ""note"": ""G3"" },
+							{ ""number"": 4, ""note"": ""D3"" },
+							{ ""number"": 5, ""note"": ""A2"" },
+							{ ""number"": 6, ""note"": ""E2"" },
+							{ ""number"": 7, ""note"": ""A1"" }
+						]
+					}
+				]
+			}");
+			return path;
+		}
+
+		private static string CreateMultipleInstrumentDefinitionFile(string fileName)
+		{
+			var path = Path.Combine(Environment.CurrentDirectory, fileName);
+			File.WriteAllText(path, @"{
+				""instruments"": [
+					{
+						""name"": ""Six String"",
+						""strings"": 6,
+						""frets"": 24,
+						""openStrings"": [
+							{ ""number"": 1, ""note"": ""E4"" },
+							{ ""number"": 2, ""note"": ""B3"" },
+							{ ""number"": 3, ""note"": ""G3"" },
+							{ ""number"": 4, ""note"": ""D3"" },
+							{ ""number"": 5, ""note"": ""A2"" },
+							{ ""number"": 6, ""note"": ""E2"" }
+						]
+					},
+					{
+						""name"": ""Seven String"",
+						""strings"": 7,
+						""frets"": 24,
+						""openStrings"": [
+							{ ""number"": 1, ""note"": ""E4"" },
+							{ ""number"": 2, ""note"": ""B3"" },
+							{ ""number"": 3, ""note"": ""G3"" },
+							{ ""number"": 4, ""note"": ""D3"" },
+							{ ""number"": 5, ""note"": ""A2"" },
+							{ ""number"": 6, ""note"": ""E2"" },
+							{ ""number"": 7, ""note"": ""A1"" }
+						]
+					}
+				]
+			}");
+			return path;
 		}
 
 		private sealed class Harness

--- a/NoteScalerTests/Services/ServiceFactoryTests.cs
+++ b/NoteScalerTests/Services/ServiceFactoryTests.cs
@@ -2,6 +2,7 @@ namespace NoteScalerTests.Services
 {
 	using NoteScaler.Config;
 	using NoteScaler.Enums;
+	using NoteScaler.Models;
 	using NoteScaler.Services;
 	using System.Linq;
 	using Xunit;
@@ -48,6 +49,36 @@ namespace NoteScalerTests.Services
 			Assert.Equal(TuningScheme.DropD, guitar.TuningScheme);
 			Assert.Equal(21, guitar.Frets);
 			Assert.Equal(6, guitar.Strings.Count());
+		}
+
+		[Fact]
+		public void StringInstrumentFactory_CreatesGuitarFromCustomDefinition()
+		{
+			var factory = new StringInstrumentFactory();
+			var definition = new StringInstrumentDefinition
+			{
+				Name = "Four String Bass",
+				NumberOfStrings = 4,
+				Frets = 20,
+				Capo = 1,
+				OpenStrings = new[]
+				{
+					new StringInstrumentStringDefinition { Number = 1, Note = "G2" },
+					new StringInstrumentStringDefinition { Number = 2, Note = "D2" },
+					new StringInstrumentStringDefinition { Number = 3, Note = "A1" },
+					new StringInstrumentStringDefinition { Number = 4, Note = "E1" }
+				}
+			};
+
+			var instrument = factory.Create(definition);
+
+			var guitar = Assert.IsType<Guitar>(instrument);
+			Assert.Equal("Four String Bass", guitar.Name);
+			Assert.Equal(20, guitar.Frets);
+			Assert.Equal(1, guitar.Capo);
+			Assert.Equal(4, guitar.Strings.Count());
+			Assert.Equal("G#2", guitar.GetNote(1, 0));
+			Assert.Equal("F1", guitar.GetNote(4, 0));
 		}
 	}
 }

--- a/NoteScalerTests/Services/StringInstrumentDefinitionLoaderTests.cs
+++ b/NoteScalerTests/Services/StringInstrumentDefinitionLoaderTests.cs
@@ -1,0 +1,162 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Services;
+	using System;
+	using System.IO;
+	using System.Linq;
+	using Xunit;
+
+	public class StringInstrumentDefinitionLoaderTests : IDisposable
+	{
+		private readonly string testDirectory;
+
+		public StringInstrumentDefinitionLoaderTests()
+		{
+			testDirectory = Path.Combine(Path.GetTempPath(), $"StringInstrumentDefinitionLoaderTests_{Guid.NewGuid():N}");
+			Directory.CreateDirectory(testDirectory);
+		}
+
+		[Fact]
+		public void Load_WhenDefinitionFileIsValid_ReturnsInstruments()
+		{
+			var path = WriteJson("valid-instruments.json", @"{
+				""instruments"": [
+					{
+						""name"": ""Seven String Drop A"",
+						""strings"": 7,
+						""frets"": 24,
+						""capo"": 2,
+						""openStrings"": [
+							{ ""number"": 1, ""note"": ""E4"" },
+							{ ""number"": 2, ""note"": ""B3"" },
+							{ ""number"": 3, ""note"": ""G3"" },
+							{ ""number"": 4, ""note"": ""D3"" },
+							{ ""number"": 5, ""note"": ""A2"" },
+							{ ""number"": 6, ""note"": ""E2"" },
+							{ ""number"": 7, ""note"": ""A1"" }
+						]
+					}
+				]
+			}");
+			var loader = new StringInstrumentDefinitionLoader();
+
+			var result = loader.Load(path);
+
+			Assert.True(result.Success, result.Error);
+			var instrument = Assert.Single(result.Instruments);
+			Assert.Equal("Seven String Drop A", instrument.Name);
+			Assert.Equal(7, instrument.NumberOfStrings);
+			Assert.Equal(24, instrument.Frets);
+			Assert.Equal(2, instrument.EffectiveCapo);
+			Assert.Equal(new[] { "E4", "B3", "G3", "D3", "A2", "E2", "A1" }, instrument.GetOpenStringNotesByStringNumber());
+		}
+
+		[Fact]
+		public void Load_WhenFileIsMissing_ReturnsControlledError()
+		{
+			var loader = new StringInstrumentDefinitionLoader();
+
+			var result = loader.Load(Path.Combine(testDirectory, "missing.json"));
+
+			Assert.False(result.Success);
+			Assert.Contains("file not found", result.Error);
+		}
+
+		[Fact]
+		public void Load_WhenJsonIsMalformed_ReturnsControlledError()
+		{
+			var path = WriteJson("malformed.json", "not json");
+			var loader = new StringInstrumentDefinitionLoader();
+
+			var result = loader.Load(path);
+
+			Assert.False(result.Success);
+			Assert.Contains("Unable to load", result.Error);
+		}
+
+		[Fact]
+		public void Load_WhenStringCountDoesNotMatchOpenStrings_ReturnsControlledError()
+		{
+			var path = WriteJson("missing-string.json", @"{
+				""instruments"": [
+					{
+						""name"": ""Broken"",
+						""strings"": 2,
+						""frets"": 24,
+						""openStrings"": [
+							{ ""number"": 1, ""note"": ""E4"" }
+						]
+					}
+				]
+			}");
+			var loader = new StringInstrumentDefinitionLoader();
+
+			var result = loader.Load(path);
+
+			Assert.False(result.Success);
+			Assert.Contains("exactly 2 open strings", result.Error);
+		}
+
+		[Fact]
+		public void Load_WhenStringNumbersAreDuplicated_ReturnsControlledError()
+		{
+			var path = WriteJson("duplicate-string.json", @"{
+				""instruments"": [
+					{
+						""name"": ""Broken"",
+						""strings"": 2,
+						""frets"": 24,
+						""openStrings"": [
+							{ ""number"": 1, ""note"": ""E4"" },
+							{ ""number"": 1, ""note"": ""B3"" }
+						]
+					}
+				]
+			}");
+			var loader = new StringInstrumentDefinitionLoader();
+
+			var result = loader.Load(path);
+
+			Assert.False(result.Success);
+			Assert.Contains("duplicate string number 1", result.Error);
+		}
+
+		[Fact]
+		public void Load_WhenOpenStringNoteIsUnsupported_ReturnsControlledError()
+		{
+			var path = WriteJson("unsupported-note.json", @"{
+				""instruments"": [
+					{
+						""name"": ""Broken"",
+						""strings"": 1,
+						""frets"": 24,
+						""openStrings"": [
+							{ ""number"": 1, ""note"": ""H4"" }
+						]
+					}
+				]
+			}");
+			var loader = new StringInstrumentDefinitionLoader();
+
+			var result = loader.Load(path);
+
+			Assert.False(result.Success);
+			Assert.Contains("unsupported note H4", result.Error);
+		}
+
+		public void Dispose()
+		{
+			if (Directory.Exists(testDirectory))
+			{
+				Directory.Delete(testDirectory, true);
+			}
+		}
+
+		private string WriteJson(string fileName, string json)
+		{
+			var path = Path.Combine(testDirectory, fileName);
+			File.WriteAllText(path, json);
+			return path;
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -52,11 +52,45 @@ Play a tab file named `anotherbrickinthewallpart2.json` from the `Tabs` director
  dotnet run --project NoteScaler -- --tab anotherbrickinthewallpart2
 ```
 
-Pause before playback, then play using a different instrument:
+Play a tab using a custom string instrument definition file:
+
+```bash
+ dotnet run --project NoteScaler -- --tab my-seven-string-tab --string-instruments NoteScaler/Instruments/custom-instruments.sample.json --string-instrument "Seven String Drop A"
+```
+
+Pause before playback, then play using a different instrument voice:
 
 ```bash
  dotnet run --project NoteScaler -- --note C --prewait 2 --speed 300 --instrument Flute
 ```
+
+## Custom string instrument JSON
+
+Custom string instruments are supplied with `--string-instruments <path>`. If the file contains more than one instrument, select one with `--string-instrument <name>`.
+
+```json
+{
+  "instruments": [
+    {
+      "name": "Seven String Drop A",
+      "strings": 7,
+      "frets": 24,
+      "capo": 0,
+      "openStrings": [
+        { "number": 1, "note": "E4" },
+        { "number": 2, "note": "B3" },
+        { "number": 3, "note": "G3" },
+        { "number": 4, "note": "D3" },
+        { "number": 5, "note": "A2" },
+        { "number": 6, "note": "E2" },
+        { "number": 7, "note": "A1" }
+      ]
+    }
+  ]
+}
+```
+
+`capo` is optional and defaults to `0`. When supplied, NoteScaler treats the configured open string note as the physical open tuning and shifts the sounding open note upward by the capo fret count.
 
 ## Command-line options
 
@@ -71,6 +105,8 @@ Pause before playback, then play using a different instrument:
 | `-n` | `--note` | `null` | Displays details for a note and plays its major, minor, and relative minor scales. |
 | `-f` | `--file` | `null` | Plays a JSON song file from the `Songs` directory. Pass the file name without `.json`. |
 | `-t` | `--tab` | `null` | Plays a JSON tab file from the `Tabs` directory. Pass the file name without `.json`. |
+|  | `--string-instruments` | `null` | Path to a JSON file that defines custom string instruments for tab playback. |
+|  | `--string-instrument` | `null` | Name of the custom string instrument to use from `--string-instruments`. Required when the file defines more than one instrument. |
 
 ## Operation order
 
@@ -80,7 +116,7 @@ When multiple operation options are supplied, NoteScaler processes them in this 
 2. Apply `--prewait` if configured.
 3. Create the playable sequence.
 4. Process `--note` if supplied.
-5. Process `--tab` if supplied.
+5. Process `--tab` if supplied. If `--string-instruments` is supplied, the selected custom string instrument is used for tab fret resolution.
 6. Process `--file` if supplied.
 
 That means a command can technically include more than one operation option, but the clearest usage is to run one primary operation at a time: `--note`, `--tab`, or `--file`.


### PR DESCRIPTION
## Summary

Solves #48 by adding dynamic string instrument definitions for tab playback while keeping built-in tunings available as the default fallback.

## What changed

- Added a custom string instrument JSON model:
  - `StringInstrumentDefinitionDocument`
  - `StringInstrumentDefinition`
  - `StringInstrumentStringDefinition`
  - `StringInstrumentDefinitionLoadResult`
- Added `IStringInstrumentDefinitionLoader` and `StringInstrumentDefinitionLoader`.
- Added validation for:
  - missing definition path
  - missing file
  - malformed JSON
  - empty instrument collections
  - duplicate instrument names
  - missing instrument names
  - invalid string count / fret count
  - invalid capo location
  - mismatched string count vs open string definitions
  - duplicate string numbers
  - invalid string numbers
  - unsupported open-string notes
  - capo-transposed notes that exceed the supported pitch range
- Added `--string-instruments <path>` for loading custom instruments.
- Added `--string-instrument <name>` for selecting one when the file defines more than one instrument.
- Updated tab playback so custom instruments can be used for fret-to-note conversion.
- Added support for non-six-string instruments through `StringInstrumentDefinition`.
- Added capo handling by shifting the sounding open string note upward by the capo fret count.
- Added a sample custom instrument JSON file.
- Updated README usage and option docs.

## Design note

I did not move every built-in instrument/tuning into external JSON in this slice. Built-ins remain available without a user-provided file, which keeps NoteScaler runnable out of the box. The new path allows external JSON definitions to override/extend behavior for tab playback without making the app dependent on a configuration file.

## TDD notes

Added behavior-focused coverage for:

- loading valid custom instrument JSON
- controlled loader errors for missing/malformed/invalid JSON
- custom instrument factory creation
- capo transposition
- runner tab playback with a seven-string custom instrument
- runner error when multiple custom instruments are available without a selected name

## Validation

- Local test execution was not available in this environment because the .NET SDK is not installed here.
- CI should run the full build/test/coverage flow on the pull request.

No merge to `master`. Scott will review and merge if approved.