### PR TITLE
Add guitar performance event model

### DIFF
--- a/NoteScaler/Enums/GuitarArticulation.cs
+++ b/NoteScaler/Enums/GuitarArticulation.cs
@@ -1,0 +1,15 @@
+namespace NoteScaler.Enums
+{
+	public enum GuitarArticulation
+	{
+		Pick,
+		StrumDown,
+		StrumUp,
+		LetRing,
+		PalmMute,
+		Mute,
+		HammerOn,
+		PullOff,
+		Slide
+	}
+}

--- a/NoteScaler/Models/GuitarPerformanceEvent.cs
+++ b/NoteScaler/Models/GuitarPerformanceEvent.cs
@@ -1,0 +1,33 @@
+namespace NoteScaler.Models
+{
+	using NoteScaler.Enums;
+
+	public sealed class GuitarPerformanceEvent
+	{
+		public GuitarPerformanceEvent(
+			string note,
+			int stringNumber,
+			int fret,
+			int startOffsetMilliseconds,
+			int durationMilliseconds,
+			int velocity = 100,
+			GuitarArticulation articulation = GuitarArticulation.Pick)
+		{
+			Note = note;
+			StringNumber = stringNumber;
+			Fret = fret;
+			StartOffsetMilliseconds = startOffsetMilliseconds;
+			DurationMilliseconds = durationMilliseconds;
+			Velocity = velocity;
+			Articulation = articulation;
+		}
+
+		public string Note { get; }
+		public int StringNumber { get; }
+		public int Fret { get; }
+		public int StartOffsetMilliseconds { get; }
+		public int DurationMilliseconds { get; }
+		public int Velocity { get; }
+		public GuitarArticulation Articulation { get; }
+	}
+}

--- a/NoteScaler/Program.cs
+++ b/NoteScaler/Program.cs
@@ -25,6 +25,7 @@
 			services.AddSingleton<IStringInstrumentDefinitionLoader, StringInstrumentDefinitionLoader>();
 			services.AddSingleton<IStringInstrumentCatalog>(_ => StringInstrumentCatalog.LoadDefaultCatalog());
 			services.AddSingleton<IStringInstrumentFactory, StringInstrumentFactory>();
+			services.AddSingleton<IGuitarPerformanceEventFactory, GuitarPerformanceEventFactory>();
 			services.AddSingleton<IMusicNoteCache, MusicNoteCache>();
 			services.AddSingleton<MusicNoteScaleBuilder>();
 			services.AddSingleton<MusicNoteFrequencyCalculator>();

--- a/NoteScaler/Services/GuitarPerformanceEventFactory.cs
+++ b/NoteScaler/Services/GuitarPerformanceEventFactory.cs
@@ -1,0 +1,59 @@
+namespace NoteScaler.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Interfaces;
+	using NoteScaler.Models;
+	using NoteScaler.Services.Interfaces;
+	using System.Collections.Generic;
+	using System.Linq;
+
+	public sealed class GuitarPerformanceEventFactory : IGuitarPerformanceEventFactory
+	{
+		public IEnumerable<GuitarPerformanceEvent> Create(IStringInstrument stringInstrument, Tablature tablature, int measureTime, int velocity = 100)
+		{
+			var startOffsetMilliseconds = 0;
+			foreach (var group in GetGroups(tablature))
+			{
+				var events = group
+					.Select(item => BuildEvent(stringInstrument, item, measureTime, startOffsetMilliseconds, velocity))
+					.ToArray();
+
+				foreach (var currentEvent in events)
+				{
+					yield return currentEvent;
+				}
+
+				startOffsetMilliseconds += events.Any() ? events.Max(item => item.DurationMilliseconds) : measureTime;
+			}
+		}
+
+		private static IEnumerable<string[]> GetGroups(Tablature tablature)
+		{
+			return (tablature?.TabString ?? string.Empty)
+				.Split(',')
+				.Where(group => !string.IsNullOrWhiteSpace(group))
+				.Select(group => group.Split('|'));
+		}
+
+		private static GuitarPerformanceEvent BuildEvent(IStringInstrument stringInstrument, string tabItem, int measureTime, int startOffsetMilliseconds, int velocity)
+		{
+			var parts = tabItem.Split('-');
+			var stringNumber = int.Parse(parts[0]);
+			var fret = int.Parse(parts[1]);
+			var durationMilliseconds = GetDurationMilliseconds(parts, measureTime);
+			var note = stringInstrument.GetNote(stringNumber, fret);
+
+			return new GuitarPerformanceEvent(note, stringNumber, fret, startOffsetMilliseconds, durationMilliseconds, velocity, GuitarArticulation.Pick);
+		}
+
+		private static int GetDurationMilliseconds(string[] parts, int measureTime)
+		{
+			if (parts.Length > 2)
+			{
+				return (int)(measureTime * float.Parse(parts[2]));
+			}
+
+			return measureTime;
+		}
+	}
+}

--- a/NoteScaler/Services/Interfaces/IGuitarPerformanceEventFactory.cs
+++ b/NoteScaler/Services/Interfaces/IGuitarPerformanceEventFactory.cs
@@ -1,0 +1,11 @@
+namespace NoteScaler.Services.Interfaces
+{
+	using NoteScaler.Interfaces;
+	using NoteScaler.Models;
+	using System.Collections.Generic;
+
+	public interface IGuitarPerformanceEventFactory
+	{
+		IEnumerable<GuitarPerformanceEvent> Create(IStringInstrument stringInstrument, Tablature tablature, int measureTime, int velocity = 100);
+	}
+}

--- a/NoteScalerTests/Services/GuitarPerformanceEventFactoryTests.cs
+++ b/NoteScalerTests/Services/GuitarPerformanceEventFactoryTests.cs
@@ -1,0 +1,109 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using NoteScaler.Services;
+	using System.Linq;
+	using Xunit;
+
+	public class GuitarPerformanceEventFactoryTests
+	{
+		[Fact]
+		public void Create_WhenTabContainsSingleFrettedNote_PreservesGuitarMetadata()
+		{
+			var factory = new GuitarPerformanceEventFactory();
+			var guitar = new Guitar(TuningScheme.Standard, 24);
+			var tablature = new Tablature
+			{
+				Name = "Single Note",
+				Tuning = "Standard",
+				TabString = "1-3"
+			};
+
+			var performanceEvent = Assert.Single(factory.Create(guitar, tablature, 1000));
+
+			Assert.Equal("G4", performanceEvent.Note);
+			Assert.Equal(1, performanceEvent.StringNumber);
+			Assert.Equal(3, performanceEvent.Fret);
+			Assert.Equal(0, performanceEvent.StartOffsetMilliseconds);
+			Assert.Equal(1000, performanceEvent.DurationMilliseconds);
+			Assert.Equal(100, performanceEvent.Velocity);
+			Assert.Equal(GuitarArticulation.Pick, performanceEvent.Articulation);
+		}
+
+		[Fact]
+		public void Create_WhenTabContainsChordGroup_UsesSameStartOffsetForAllChordNotes()
+		{
+			var factory = new GuitarPerformanceEventFactory();
+			var guitar = new Guitar(TuningScheme.Standard, 24);
+			var tablature = new Tablature
+			{
+				Name = "Chord",
+				Tuning = "Standard",
+				TabString = "1-0|2-1|3-0"
+			};
+
+			var performanceEvents = factory.Create(guitar, tablature, 1000).ToArray();
+
+			Assert.Equal(3, performanceEvents.Length);
+			Assert.All(performanceEvents, performanceEvent => Assert.Equal(0, performanceEvent.StartOffsetMilliseconds));
+			Assert.Equal(new[] { "E4", "C4", "G3" }, performanceEvents.Select(performanceEvent => performanceEvent.Note));
+		}
+
+		[Fact]
+		public void Create_WhenTabContainsSequentialGroups_AdvancesStartOffsetByGroupDuration()
+		{
+			var factory = new GuitarPerformanceEventFactory();
+			var guitar = new Guitar(TuningScheme.Standard, 24);
+			var tablature = new Tablature
+			{
+				Name = "Sequential",
+				Tuning = "Standard",
+				TabString = "1-0,2-1,3-0"
+			};
+
+			var performanceEvents = factory.Create(guitar, tablature, 1000).ToArray();
+
+			Assert.Equal(new[] { 0, 1000, 2000 }, performanceEvents.Select(performanceEvent => performanceEvent.StartOffsetMilliseconds));
+		}
+
+		[Fact]
+		public void Create_WhenTabContainsDurationModifier_UsesMeasureTimePercentage()
+		{
+			var factory = new GuitarPerformanceEventFactory();
+			var guitar = new Guitar(TuningScheme.Standard, 24);
+			var tablature = new Tablature
+			{
+				Name = "Duration",
+				Tuning = "Standard",
+				TabString = "1-0-0.5,2-1"
+			};
+
+			var performanceEvents = factory.Create(guitar, tablature, 1000).ToArray();
+
+			Assert.Equal(500, performanceEvents[0].DurationMilliseconds);
+			Assert.Equal(0, performanceEvents[0].StartOffsetMilliseconds);
+			Assert.Equal(1000, performanceEvents[1].DurationMilliseconds);
+			Assert.Equal(500, performanceEvents[1].StartOffsetMilliseconds);
+		}
+
+		[Fact]
+		public void Create_WhenChordContainsMixedDurations_AdvancesStartOffsetByLongestChordDuration()
+		{
+			var factory = new GuitarPerformanceEventFactory();
+			var guitar = new Guitar(TuningScheme.Standard, 24);
+			var tablature = new Tablature
+			{
+				Name = "Mixed Duration Chord",
+				Tuning = "Standard",
+				TabString = "1-0-0.5|2-1,3-0"
+			};
+
+			var performanceEvents = factory.Create(guitar, tablature, 1000).ToArray();
+
+			Assert.Equal(0, performanceEvents[0].StartOffsetMilliseconds);
+			Assert.Equal(0, performanceEvents[1].StartOffsetMilliseconds);
+			Assert.Equal(1000, performanceEvents[2].StartOffsetMilliseconds);
+		}
+	}
+}

--- a/docs/playback/guitar-performance-events.md
+++ b/docs/playback/guitar-performance-events.md
@@ -1,0 +1,53 @@
+# Guitar Performance Events
+
+`GuitarPerformanceEvent` is the neutral model used to preserve guitar-specific information from tablature before any renderer consumes it.
+
+The existing playback path can still convert tabs directly into note names and durations. This model exists so future renderers, such as MIDI export, SoundFont rendering, physical modeling, or hardware output, do not need to re-parse tab text or guess guitar metadata after it has been discarded.
+
+## Preserved Data
+
+Each event includes:
+
+- note name
+- string number
+- fret number
+- start offset in milliseconds
+- duration in milliseconds
+- velocity
+- articulation
+
+## Timing Rules
+
+Comma-separated tab groups advance time sequentially.
+
+```text
+1-0,2-1,3-0
+```
+
+The events start at `0`, `measureTime`, and `measureTime * 2`.
+
+Pipe-separated tab notes are treated as a chord group.
+
+```text
+1-0|2-1|3-0
+```
+
+All events in the group share the same start offset by default.
+
+Duration modifiers still use the existing tab duration syntax.
+
+```text
+1-0-0.5
+```
+
+With a `measureTime` of `1000`, this event lasts `500` milliseconds.
+
+## Renderer Use
+
+Future renderers should consume `GuitarPerformanceEvent` rather than re-parsing tab strings.
+
+The intended serial path is:
+
+```text
+Tablature -> GuitarPerformanceEvent -> MIDI export -> SoundFont rendering -> optional hardware output
+```


### PR DESCRIPTION
## Summary

Resolves #54.

Adds a sidecar guitar performance event model and factory so tab playback metadata can be preserved for #55.

## Changes

- Add performance event model.
- Add articulation enum.
- Add performance event factory and interface.
- Register the factory with DI.
- Add focused tests.
- Add playback event documentation.

Existing playback behavior is unchanged.

No merge to master. Scott will review and merge if approved.