### PR TITLE
Export tab playback to MIDI file

### DIFF
--- a/NoteScaler/Config/NoteScalerOptions.cs
+++ b/NoteScaler/Config/NoteScalerOptions.cs
@@ -33,5 +33,8 @@
 
 		[Option('t', "tab", Default = null, HelpText = "Name of the tab file to play from the Tabs directory.")]
 		public string Tab { get; set; }
+
+		[Option("export-midi", Default = null, HelpText = "Path to a MIDI file to export when playing a tab.")]
+		public string ExportMidi { get; set; }
 	}
 }

--- a/NoteScaler/Program.cs
+++ b/NoteScaler/Program.cs
@@ -26,6 +26,7 @@
 			services.AddSingleton<IStringInstrumentCatalog>(_ => StringInstrumentCatalog.LoadDefaultCatalog());
 			services.AddSingleton<IStringInstrumentFactory, StringInstrumentFactory>();
 			services.AddSingleton<IGuitarPerformanceEventFactory, GuitarPerformanceEventFactory>();
+			services.AddSingleton<IMidiFileExporter, MidiFileExporter>();
 			services.AddSingleton<IMusicNoteCache, MusicNoteCache>();
 			services.AddSingleton<MusicNoteScaleBuilder>();
 			services.AddSingleton<MusicNoteFrequencyCalculator>();

--- a/NoteScaler/Services/Interfaces/IMidiFileExporter.cs
+++ b/NoteScaler/Services/Interfaces/IMidiFileExporter.cs
@@ -1,0 +1,10 @@
+namespace NoteScaler.Services.Interfaces
+{
+	using NoteScaler.Models;
+	using System.Collections.Generic;
+
+	public interface IMidiFileExporter
+	{
+		void Export(IEnumerable<GuitarPerformanceEvent> performanceEvents, string outputPath);
+	}
+}

--- a/NoteScaler/Services/MidiFileExporter.cs
+++ b/NoteScaler/Services/MidiFileExporter.cs
@@ -1,0 +1,200 @@
+namespace NoteScaler.Services
+{
+	using NoteScaler.Models;
+	using NoteScaler.Services.Interfaces;
+	using System;
+	using System.Collections.Generic;
+	using System.IO;
+	using System.Linq;
+	using System.Text.RegularExpressions;
+
+	public sealed class MidiFileExporter : IMidiFileExporter
+	{
+		private const short TicksPerQuarterNote = 1000;
+		private const int MicrosecondsPerQuarterNote = 1000000;
+		private const int MidiChannel = 0;
+		private const int DefaultVelocity = 100;
+
+		public void Export(IEnumerable<GuitarPerformanceEvent> performanceEvents, string outputPath)
+		{
+			if (string.IsNullOrWhiteSpace(outputPath))
+			{
+				throw new ArgumentException("MIDI output path is required.", nameof(outputPath));
+			}
+
+			var events = performanceEvents?.ToArray() ?? throw new ArgumentNullException(nameof(performanceEvents));
+			var directory = Path.GetDirectoryName(outputPath);
+			if (!string.IsNullOrEmpty(directory))
+			{
+				Directory.CreateDirectory(directory);
+			}
+
+			using var outputStream = File.Create(outputPath);
+			WriteHeader(outputStream);
+			WriteTrack(outputStream, events);
+		}
+
+		private static void WriteHeader(Stream outputStream)
+		{
+			WriteAscii(outputStream, "MThd");
+			WriteInt32(outputStream, 6);
+			WriteInt16(outputStream, 0);
+			WriteInt16(outputStream, 1);
+			WriteInt16(outputStream, TicksPerQuarterNote);
+		}
+
+		private static void WriteTrack(Stream outputStream, IReadOnlyCollection<GuitarPerformanceEvent> performanceEvents)
+		{
+			using var trackStream = new MemoryStream();
+			WriteTempoEvent(trackStream);
+
+			var midiEvents = performanceEvents
+				.SelectMany(CreateMidiEvents)
+				.OrderBy(midiEvent => midiEvent.Tick)
+				.ThenBy(midiEvent => midiEvent.IsNoteOn ? 1 : 0)
+				.ToArray();
+
+			var previousTick = 0;
+			foreach (var midiEvent in midiEvents)
+			{
+				WriteVariableLengthQuantity(trackStream, midiEvent.Tick - previousTick);
+				trackStream.WriteByte((byte)(midiEvent.IsNoteOn ? 0x90 + MidiChannel : 0x80 + MidiChannel));
+				trackStream.WriteByte((byte)midiEvent.NoteNumber);
+				trackStream.WriteByte((byte)midiEvent.Velocity);
+				previousTick = midiEvent.Tick;
+			}
+
+			WriteEndOfTrackEvent(trackStream);
+
+			WriteAscii(outputStream, "MTrk");
+			WriteInt32(outputStream, (int)trackStream.Length);
+			trackStream.Position = 0;
+			trackStream.CopyTo(outputStream);
+		}
+
+		private static IEnumerable<MidiNoteEvent> CreateMidiEvents(GuitarPerformanceEvent performanceEvent)
+		{
+			var noteNumber = GetMidiNoteNumber(performanceEvent.Note);
+			var velocity = performanceEvent.Velocity > 0 ? performanceEvent.Velocity : DefaultVelocity;
+			var startTick = performanceEvent.StartOffsetMilliseconds;
+			var endTick = performanceEvent.StartOffsetMilliseconds + performanceEvent.DurationMilliseconds;
+
+			yield return new MidiNoteEvent(startTick, noteNumber, velocity, true);
+			yield return new MidiNoteEvent(endTick, noteNumber, 0, false);
+		}
+
+		private static int GetMidiNoteNumber(string note)
+		{
+			var match = Regex.Match(note, "^([A-G])(#?)(-?\\d+)$");
+			if (!match.Success)
+			{
+				throw new ArgumentException($"Unsupported MIDI note: {note}", nameof(note));
+			}
+
+			var noteName = match.Groups[1].Value + match.Groups[2].Value;
+			var octave = int.Parse(match.Groups[3].Value);
+			return (octave + 1) * 12 + GetSemitone(noteName);
+		}
+
+		private static int GetSemitone(string noteName)
+		{
+			switch (noteName)
+			{
+				case "C": return 0;
+				case "C#": return 1;
+				case "D": return 2;
+				case "D#": return 3;
+				case "E": return 4;
+				case "F": return 5;
+				case "F#": return 6;
+				case "G": return 7;
+				case "G#": return 8;
+				case "A": return 9;
+				case "A#": return 10;
+				case "B": return 11;
+				default:
+					throw new ArgumentException($"Unsupported MIDI note name: {noteName}", nameof(noteName));
+			}
+		}
+
+		private static void WriteTempoEvent(Stream stream)
+		{
+			WriteVariableLengthQuantity(stream, 0);
+			stream.WriteByte(0xFF);
+			stream.WriteByte(0x51);
+			stream.WriteByte(0x03);
+			stream.WriteByte((byte)((MicrosecondsPerQuarterNote >> 16) & 0xFF));
+			stream.WriteByte((byte)((MicrosecondsPerQuarterNote >> 8) & 0xFF));
+			stream.WriteByte((byte)(MicrosecondsPerQuarterNote & 0xFF));
+		}
+
+		private static void WriteEndOfTrackEvent(Stream stream)
+		{
+			WriteVariableLengthQuantity(stream, 0);
+			stream.WriteByte(0xFF);
+			stream.WriteByte(0x2F);
+			stream.WriteByte(0x00);
+		}
+
+		private static void WriteVariableLengthQuantity(Stream stream, int value)
+		{
+			var buffer = value & 0x7F;
+			while ((value >>= 7) > 0)
+			{
+				buffer <<= 8;
+				buffer |= ((value & 0x7F) | 0x80);
+			}
+
+			while (true)
+			{
+				stream.WriteByte((byte)(buffer & 0xFF));
+				if ((buffer & 0x80) != 0)
+				{
+					buffer >>= 8;
+				}
+				else
+				{
+					break;
+				}
+			}
+		}
+
+		private static void WriteAscii(Stream stream, string value)
+		{
+			foreach (var character in value)
+			{
+				stream.WriteByte((byte)character);
+			}
+		}
+
+		private static void WriteInt16(Stream stream, short value)
+		{
+			stream.WriteByte((byte)((value >> 8) & 0xFF));
+			stream.WriteByte((byte)(value & 0xFF));
+		}
+
+		private static void WriteInt32(Stream stream, int value)
+		{
+			stream.WriteByte((byte)((value >> 24) & 0xFF));
+			stream.WriteByte((byte)((value >> 16) & 0xFF));
+			stream.WriteByte((byte)((value >> 8) & 0xFF));
+			stream.WriteByte((byte)(value & 0xFF));
+		}
+
+		private sealed class MidiNoteEvent
+		{
+			public MidiNoteEvent(int tick, int noteNumber, int velocity, bool isNoteOn)
+			{
+				Tick = tick;
+				NoteNumber = noteNumber;
+				Velocity = velocity;
+				IsNoteOn = isNoteOn;
+			}
+
+			public int Tick { get; }
+			public int NoteNumber { get; }
+			public int Velocity { get; }
+			public bool IsNoteOn { get; }
+		}
+	}
+}

--- a/NoteScaler/Services/NoteScalerRunner.cs
+++ b/NoteScaler/Services/NoteScalerRunner.cs
@@ -20,17 +20,32 @@ namespace NoteScaler.Services
 		private readonly IPlayableSequenceFactory playableSequenceFactory;
 		private readonly IStringInstrumentFactory stringInstrumentFactory;
 		private readonly IConsoleOutputService consoleOutputService;
+		private readonly IGuitarPerformanceEventFactory guitarPerformanceEventFactory;
+		private readonly IMidiFileExporter midiFileExporter;
 
 		public NoteScalerRunner(
 			ICommandLineOptionsService commandLineOptionsService,
 			IPlayableSequenceFactory playableSequenceFactory,
 			IStringInstrumentFactory stringInstrumentFactory,
 			IConsoleOutputService consoleOutputService)
+			: this(commandLineOptionsService, playableSequenceFactory, stringInstrumentFactory, consoleOutputService, new GuitarPerformanceEventFactory(), new MidiFileExporter())
+		{
+		}
+
+		public NoteScalerRunner(
+			ICommandLineOptionsService commandLineOptionsService,
+			IPlayableSequenceFactory playableSequenceFactory,
+			IStringInstrumentFactory stringInstrumentFactory,
+			IConsoleOutputService consoleOutputService,
+			IGuitarPerformanceEventFactory guitarPerformanceEventFactory,
+			IMidiFileExporter midiFileExporter)
 		{
 			this.commandLineOptionsService = commandLineOptionsService;
 			this.playableSequenceFactory = playableSequenceFactory;
 			this.stringInstrumentFactory = stringInstrumentFactory;
 			this.consoleOutputService = consoleOutputService;
+			this.guitarPerformanceEventFactory = guitarPerformanceEventFactory;
+			this.midiFileExporter = midiFileExporter;
 		}
 
 		public int Run(string[] args)
@@ -53,7 +68,7 @@ namespace NoteScaler.Services
 				playableSequence.PlayableSequenceEvent += PlayableSequence_PlayableSequenceEvent;
 
 				PlayNoteAsRequired(options.Note, options.Octave.GetValueOrDefault(), a4Reference, playableSequence);
-				PlayTabAsRequired(tabName, playableSequence);
+				PlayTabAsRequired(tabName, options.ExportMidi, playableSequence);
 				PlaySongAsRequired(key, fileName, playableSequence);
 			}
 			finally
@@ -182,7 +197,7 @@ namespace NoteScaler.Services
 			}
 		}
 
-		private void PlayTabAsRequired(string tabName, PlayableSequence playableSequence)
+		private void PlayTabAsRequired(string tabName, string exportMidi, PlayableSequence playableSequence)
 		{
 			if (!string.IsNullOrEmpty(tabName))
 			{
@@ -200,11 +215,31 @@ namespace NoteScaler.Services
 						return;
 					}
 
+					ExportTabToMidiAsRequired(exportMidi, stringInstrument, tabs, playableSequence.MeasureTime);
 					playableSequence.ConvertTabsToNoteSequence(stringInstrument, tabs);
 					playableSequence.Repeat = tabs.Repeat;
 					playableSequence.Prepare();
 					playableSequence.Play();
 				}
+			}
+		}
+
+		private void ExportTabToMidiAsRequired(string exportMidi, IStringInstrument stringInstrument, Tablature tabs, int measureTime)
+		{
+			if (string.IsNullOrWhiteSpace(exportMidi))
+			{
+				return;
+			}
+
+			try
+			{
+				var performanceEvents = guitarPerformanceEventFactory.Create(stringInstrument, tabs, measureTime);
+				midiFileExporter.Export(performanceEvents, exportMidi);
+				consoleOutputService.WriteMessage($"Exported MIDI: {exportMidi}");
+			}
+			catch (Exception ex)
+			{
+				consoleOutputService.WriteMessage(ex.Message, ConsoleColor.Red);
 			}
 		}
 

--- a/NoteScalerTests/Services/MidiFileExporterTests.cs
+++ b/NoteScalerTests/Services/MidiFileExporterTests.cs
@@ -1,0 +1,117 @@
+namespace NoteScalerTests.Services
+{
+	using NoteScaler.Enums;
+	using NoteScaler.Models;
+	using NoteScaler.Services;
+	using System;
+	using System.IO;
+	using Xunit;
+
+	public sealed class MidiFileExporterTests : IDisposable
+	{
+		private readonly string testDirectory;
+
+		public MidiFileExporterTests()
+		{
+			testDirectory = Path.Combine(Path.GetTempPath(), $"MidiFileExporterTests_{Guid.NewGuid():N}");
+			Directory.CreateDirectory(testDirectory);
+		}
+
+		[Fact]
+		public void Export_WritesStandardMidiHeaderAndTrackChunk()
+		{
+			var outputPath = Path.Combine(testDirectory, "single-note.mid");
+			var exporter = new MidiFileExporter();
+			var performanceEvents = new[]
+			{
+				new GuitarPerformanceEvent("C4", 1, 0, 0, 500)
+			};
+
+			exporter.Export(performanceEvents, outputPath);
+
+			var bytes = File.ReadAllBytes(outputPath);
+			Assert.Equal("MThd", ReadAscii(bytes, 0, 4));
+			Assert.Equal("MTrk", ReadAscii(bytes, 14, 4));
+		}
+
+		[Fact]
+		public void Export_WhenSingleEventExists_WritesMatchingNoteOnAndNoteOffEvents()
+		{
+			var outputPath = Path.Combine(testDirectory, "single-note.mid");
+			var exporter = new MidiFileExporter();
+			var performanceEvents = new[]
+			{
+				new GuitarPerformanceEvent("C4", 1, 0, 0, 500, 87, GuitarArticulation.Pick)
+			};
+
+			exporter.Export(performanceEvents, outputPath);
+
+			var bytes = File.ReadAllBytes(outputPath);
+			Assert.Contains(new byte[] { 0x90, 60, 87 }, bytes);
+			Assert.Contains(new byte[] { 0x80, 60, 0 }, bytes);
+		}
+
+		[Fact]
+		public void Export_WhenSharpNoteExists_WritesCorrectMidiNoteNumber()
+		{
+			var outputPath = Path.Combine(testDirectory, "sharp-note.mid");
+			var exporter = new MidiFileExporter();
+			var performanceEvents = new[]
+			{
+				new GuitarPerformanceEvent("C#4", 1, 0, 0, 500)
+			};
+
+			exporter.Export(performanceEvents, outputPath);
+
+			var bytes = File.ReadAllBytes(outputPath);
+			Assert.Contains(new byte[] { 0x90, 61, 100 }, bytes);
+			Assert.Contains(new byte[] { 0x80, 61, 0 }, bytes);
+		}
+
+		[Fact]
+		public void Export_WhenChordEventsHaveSameStartOffset_WritesNoteOnsAtSameTick()
+		{
+			var outputPath = Path.Combine(testDirectory, "chord.mid");
+			var exporter = new MidiFileExporter();
+			var performanceEvents = new[]
+			{
+				new GuitarPerformanceEvent("E4", 1, 0, 0, 500),
+				new GuitarPerformanceEvent("C4", 2, 1, 0, 500),
+				new GuitarPerformanceEvent("G3", 3, 0, 0, 500)
+			};
+
+			exporter.Export(performanceEvents, outputPath);
+
+			var bytes = File.ReadAllBytes(outputPath);
+			Assert.Contains(new byte[] { 0x00, 0x90, 64, 100, 0x00, 0x90, 60, 100, 0x00, 0x90, 55, 100 }, bytes);
+		}
+
+		[Fact]
+		public void Export_WhenOutputDirectoryDoesNotExist_CreatesDirectoryAndFile()
+		{
+			var outputPath = Path.Combine(testDirectory, "nested", "export.mid");
+			var exporter = new MidiFileExporter();
+			var performanceEvents = new[]
+			{
+				new GuitarPerformanceEvent("C4", 1, 0, 0, 500)
+			};
+
+			exporter.Export(performanceEvents, outputPath);
+
+			Assert.True(File.Exists(outputPath));
+		}
+
+		public void Dispose()
+		{
+			if (Directory.Exists(testDirectory))
+			{
+				Directory.Delete(testDirectory, true);
+			}
+		}
+
+		private static string ReadAscii(byte[] bytes, int startIndex, int length)
+		{
+			return System.Text.Encoding.ASCII.GetString(bytes, startIndex, length);
+		}
+	}
+}

--- a/NoteScalerTests/Services/MidiFileExporterTests.cs
+++ b/NoteScalerTests/Services/MidiFileExporterTests.cs
@@ -47,8 +47,8 @@ namespace NoteScalerTests.Services
 			exporter.Export(performanceEvents, outputPath);
 
 			var bytes = File.ReadAllBytes(outputPath);
-			Assert.Contains(new byte[] { 0x90, 60, 87 }, bytes);
-			Assert.Contains(new byte[] { 0x80, 60, 0 }, bytes);
+			AssertContains(bytes, new byte[] { 0x90, 60, 87 });
+			AssertContains(bytes, new byte[] { 0x80, 60, 0 });
 		}
 
 		[Fact]
@@ -64,8 +64,8 @@ namespace NoteScalerTests.Services
 			exporter.Export(performanceEvents, outputPath);
 
 			var bytes = File.ReadAllBytes(outputPath);
-			Assert.Contains(new byte[] { 0x90, 61, 100 }, bytes);
-			Assert.Contains(new byte[] { 0x80, 61, 0 }, bytes);
+			AssertContains(bytes, new byte[] { 0x90, 61, 100 });
+			AssertContains(bytes, new byte[] { 0x80, 61, 0 });
 		}
 
 		[Fact]
@@ -83,7 +83,7 @@ namespace NoteScalerTests.Services
 			exporter.Export(performanceEvents, outputPath);
 
 			var bytes = File.ReadAllBytes(outputPath);
-			Assert.Contains(new byte[] { 0x00, 0x90, 64, 100, 0x00, 0x90, 60, 100, 0x00, 0x90, 55, 100 }, bytes);
+			AssertContains(bytes, new byte[] { 0x00, 0x90, 64, 100, 0x00, 0x90, 60, 100, 0x00, 0x90, 55, 100 });
 		}
 
 		[Fact]
@@ -112,6 +112,34 @@ namespace NoteScalerTests.Services
 		private static string ReadAscii(byte[] bytes, int startIndex, int length)
 		{
 			return System.Text.Encoding.ASCII.GetString(bytes, startIndex, length);
+		}
+
+		private static void AssertContains(byte[] bytes, byte[] expectedSequence)
+		{
+			Assert.True(ContainsSequence(bytes, expectedSequence), $"Expected byte sequence was not found: {BitConverter.ToString(expectedSequence)}");
+		}
+
+		private static bool ContainsSequence(byte[] bytes, byte[] expectedSequence)
+		{
+			for (var index = 0; index <= bytes.Length - expectedSequence.Length; index++)
+			{
+				var found = true;
+				for (var sequenceIndex = 0; sequenceIndex < expectedSequence.Length; sequenceIndex++)
+				{
+					if (bytes[index + sequenceIndex] != expectedSequence[sequenceIndex])
+					{
+						found = false;
+						break;
+					}
+				}
+
+				if (found)
+				{
+					return true;
+				}
+			}
+
+			return false;
 		}
 	}
 }

--- a/NoteScalerTests/Services/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/Services/NoteScalerRunnerTests.cs
@@ -167,6 +167,20 @@ namespace NoteScalerTests.Services
 			Assert.Contains(harness.Console.Messages, message => message.Contains("Unsupported string instrument: Not A Real Instrument"));
 		}
 
+		[Fact]
+		public void Run_WhenExportMidiIsRequested_WritesMidiFileAndKeepsTabPlayback()
+		{
+			CreateTabFile("runner-midi-tab", "Standard");
+			var outputPath = Path.Combine(testDirectory, "runner-midi-tab.mid");
+			var harness = CreateHarness();
+
+			harness.Runner.Run(new[] { "--tab", "runner-midi-tab", "--export-midi", outputPath });
+
+			Assert.True(File.Exists(outputPath));
+			Assert.Contains(harness.Console.Messages, message => message.Contains("Exported MIDI"));
+			Assert.True(harness.Player.PlayCount > 0);
+		}
+
 		public void Dispose()
 		{
 			Environment.CurrentDirectory = originalCurrentDirectory;

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Play a tab whose JSON file references an instrument by name:
  dotnet run --project NoteScaler -- --tab my-seven-string-tab
 ```
 
+Play a tab and export the same guitar performance events to a MIDI file:
+
+```bash
+ dotnet run --project NoteScaler -- --tab my-seven-string-tab --export-midi my-seven-string-tab.mid
+```
+
 Pause before playback, then play using a different instrument voice:
 
 ```bash
@@ -115,6 +121,18 @@ Supplemental instruments use this JSON shape:
 
 Base instrument names are immutable. If the supplemental file defines a name or alias that already exists in the embedded base catalog, the embedded base definition wins.
 
+## MIDI export
+
+MIDI export is file-based. It does not require a MIDI-capable guitar amp.
+
+When `--export-midi` is supplied with `--tab`, NoteScaler writes a standard `.mid` file from the guitar performance events and then continues normal tab playback.
+
+```bash
+ dotnet run --project NoteScaler -- --tab anotherbrickinthewallpart2 --export-midi anotherbrickinthewallpart2.mid
+```
+
+The MIDI file contains note-on and note-off events derived from the resolved tab string, fret, note, start offset, duration, velocity, and articulation metadata.
+
 ## Command-line options
 
 | Short | Long | Default | Description |
@@ -128,6 +146,7 @@ Base instrument names are immutable. If the supplemental file defines a name or 
 | `-n` | `--note` | `null` | Displays details for a note and plays its major, minor, and relative minor scales. |
 | `-f` | `--file` | `null` | Plays a JSON song file from the `Songs` directory. Pass the file name without `.json`. |
 | `-t` | `--tab` | `null` | Plays a JSON tab file from the `Tabs` directory. Pass the file name without `.json`. |
+|  | `--export-midi` | `null` | Writes a MIDI file when playing a tab. |
 
 ## Operation order
 
@@ -137,7 +156,7 @@ When multiple operation options are supplied, NoteScaler processes them in this 
 2. Apply `--prewait` if configured.
 3. Create the playable sequence.
 4. Process `--note` if supplied.
-5. Process `--tab` if supplied. The tab `tuning` value is resolved from the embedded base catalog plus the editable supplemental catalog.
+5. Process `--tab` if supplied. The tab `tuning` value is resolved from the embedded base catalog plus the editable supplemental catalog. If `--export-midi` is supplied, a MIDI file is written before tab playback.
 6. Process `--file` if supplied.
 
 That means a command can technically include more than one operation option, but the clearest usage is to run one primary operation at a time: `--note`, `--tab`, or `--file`.
@@ -168,19 +187,22 @@ flowchart TD
     O --> P{Tab loaded?}
     P -->|Yes| Q[Apply tab defaults and tuning]
     Q --> R[Resolve string instrument from JSON catalogs]
-    R --> S[Convert tab frets to notes]
-    S --> T[Prepare and play tab sequence]
-    P -->|No| U[Write tab load error]
-    N -->|No| V{--file supplied?}
-    T --> V
-    U --> V
+    R --> S{--export-midi supplied?}
+    S -->|Yes| T[Write MIDI file]
+    S -->|No| U[Convert tab frets to notes]
+    T --> U
+    U --> V[Prepare and play tab sequence]
+    P -->|No| W[Write tab load error]
+    N -->|No| X{--file supplied?}
+    V --> X
+    W --> X
 
-    V -->|Yes| W[Load song file from Songs]
-    W --> X{Song loaded?}
-    X -->|Yes| Y[Select requested/default key]
-    Y --> AA[Prepare and play song sequence]
-    X -->|No| AB[Write song load error]
-    V -->|No| Z[Exit]
-    AA --> Z
-    AB --> Z
+    X -->|Yes| Y[Load song file from Songs]
+    Y --> AA{Song loaded?}
+    AA -->|Yes| AB[Select requested/default key]
+    AB --> AC[Prepare and play song sequence]
+    AA -->|No| AD[Write song load error]
+    X -->|No| Z[Exit]
+    AC --> Z
+    AD --> Z
 ```


### PR DESCRIPTION
## Summary

Resolves #55.

Adds file-based MIDI export for tab playback using the guitar performance events introduced by #54.

## Changes

- Add `IMidiFileExporter`.
- Add `MidiFileExporter` that writes a standard single-track `.mid` file.
- Add `--export-midi <path>` command-line option.
- Wire tab playback so MIDI export is additive and existing playback still runs.
- Register the MIDI exporter with DI.
- Add tests for MIDI header/track output, note-on/note-off events, sharp notes, chord timing, directory creation, and runner export behavior.
- Update README with MIDI export usage.

## Design note

This does not require a MIDI-capable amp. The output is a `.mid` file that can be rendered by the computer, a DAW, a SoundFont renderer, or a future hardware path.

## Validation

Local tests were not run because this environment does not have the .NET SDK. CI should validate the branch.

No merge to master. Scott will review and merge if approved.