### PR TITLE
Set guitar program for MIDI export

### DIFF
--- a/NoteScaler/Services/MidiFileExporter.cs
+++ b/NoteScaler/Services/MidiFileExporter.cs
@@ -14,6 +14,7 @@ namespace NoteScaler.Services
 		private const int MicrosecondsPerQuarterNote = 1000000;
 		private const int MidiChannel = 0;
 		private const int DefaultVelocity = 100;
+		private const int DefaultGuitarProgram = 24;
 
 		public void Export(IEnumerable<GuitarPerformanceEvent> performanceEvents, string outputPath)
 		{
@@ -47,6 +48,7 @@ namespace NoteScaler.Services
 		{
 			using var trackStream = new MemoryStream();
 			WriteTempoEvent(trackStream);
+			WriteProgramChangeEvent(trackStream);
 
 			var midiEvents = performanceEvents
 				.SelectMany(CreateMidiEvents)
@@ -126,6 +128,13 @@ namespace NoteScaler.Services
 			stream.WriteByte((byte)((MicrosecondsPerQuarterNote >> 16) & 0xFF));
 			stream.WriteByte((byte)((MicrosecondsPerQuarterNote >> 8) & 0xFF));
 			stream.WriteByte((byte)(MicrosecondsPerQuarterNote & 0xFF));
+		}
+
+		private static void WriteProgramChangeEvent(Stream stream)
+		{
+			WriteVariableLengthQuantity(stream, 0);
+			stream.WriteByte(0xC0 + MidiChannel);
+			stream.WriteByte(DefaultGuitarProgram);
 		}
 
 		private static void WriteEndOfTrackEvent(Stream stream)

--- a/NoteScalerTests/Services/MidiFileExporterTests.cs
+++ b/NoteScalerTests/Services/MidiFileExporterTests.cs
@@ -35,6 +35,26 @@ namespace NoteScalerTests.Services
 		}
 
 		[Fact]
+		public void Export_WritesGuitarProgramChangeBeforeNoteEvents()
+		{
+			var outputPath = Path.Combine(testDirectory, "guitar-program.mid");
+			var exporter = new MidiFileExporter();
+			var performanceEvents = new[]
+			{
+				new GuitarPerformanceEvent("C4", 1, 0, 0, 500)
+			};
+
+			exporter.Export(performanceEvents, outputPath);
+
+			var bytes = File.ReadAllBytes(outputPath);
+			var programChangeIndex = IndexOf(bytes, new byte[] { 0x00, 0xC0, 24 });
+			var noteOnIndex = IndexOf(bytes, new byte[] { 0x00, 0x90, 60, 100 });
+			Assert.True(programChangeIndex >= 0, "Expected default guitar program change was not found.");
+			Assert.True(noteOnIndex >= 0, "Expected first note-on event was not found.");
+			Assert.True(programChangeIndex < noteOnIndex, "Expected program change to be written before note events.");
+		}
+
+		[Fact]
 		public void Export_WhenSingleEventExists_WritesMatchingNoteOnAndNoteOffEvents()
 		{
 			var outputPath = Path.Combine(testDirectory, "single-note.mid");
@@ -121,6 +141,11 @@ namespace NoteScalerTests.Services
 
 		private static bool ContainsSequence(byte[] bytes, byte[] expectedSequence)
 		{
+			return IndexOf(bytes, expectedSequence) >= 0;
+		}
+
+		private static int IndexOf(byte[] bytes, byte[] expectedSequence)
+		{
 			for (var index = 0; index <= bytes.Length - expectedSequence.Length; index++)
 			{
 				var found = true;
@@ -135,11 +160,11 @@ namespace NoteScalerTests.Services
 
 				if (found)
 				{
-					return true;
+					return index;
 				}
 			}
 
-			return false;
+			return -1;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Resolves #58.

Adds a default MIDI Program Change event before exported tab note events so MIDI renderers are told to use a guitar patch instead of falling back to piano.

## Changes

- Writes Program Change `0xC0 24` after the tempo event and before note events.
- Uses General MIDI program 25 in 1-based numbering: Acoustic Guitar nylon.
- Adds a test proving the Program Change appears before the first note-on event.
- Keeps existing MIDI note timing and tab playback behavior unchanged.

## Validation

Local tests were not run because this environment does not have the .NET SDK. CI should validate the branch.

No merge to master. Scott will review and merge if approved.