### PR TITLE
Export song playback to MIDI file

### DIFF
--- a/NoteScaler/Services/Interfaces/IMidiFileExporter.cs
+++ b/NoteScaler/Services/Interfaces/IMidiFileExporter.cs
@@ -6,5 +6,6 @@ namespace NoteScaler.Services.Interfaces
 	public interface IMidiFileExporter
 	{
 		void Export(IEnumerable<GuitarPerformanceEvent> performanceEvents, string outputPath);
+		void ExportCompositeNotes(IEnumerable<CompositeNote> compositeNotes, string outputPath);
 	}
 }

--- a/NoteScaler/Services/MidiFileExporter.cs
+++ b/NoteScaler/Services/MidiFileExporter.cs
@@ -18,12 +18,23 @@ namespace NoteScaler.Services
 
 		public void Export(IEnumerable<GuitarPerformanceEvent> performanceEvents, string outputPath)
 		{
+			var events = performanceEvents?.SelectMany(CreateMidiEvents).ToArray() ?? throw new ArgumentNullException(nameof(performanceEvents));
+			ExportMidiEvents(events, outputPath);
+		}
+
+		public void ExportCompositeNotes(IEnumerable<CompositeNote> compositeNotes, string outputPath)
+		{
+			var events = CreateMidiEvents(compositeNotes?.ToArray() ?? throw new ArgumentNullException(nameof(compositeNotes))).ToArray();
+			ExportMidiEvents(events, outputPath);
+		}
+
+		private static void ExportMidiEvents(IReadOnlyCollection<MidiNoteEvent> events, string outputPath)
+		{
 			if (string.IsNullOrWhiteSpace(outputPath))
 			{
 				throw new ArgumentException("MIDI output path is required.", nameof(outputPath));
 			}
 
-			var events = performanceEvents?.ToArray() ?? throw new ArgumentNullException(nameof(performanceEvents));
 			var directory = Path.GetDirectoryName(outputPath);
 			if (!string.IsNullOrEmpty(directory))
 			{
@@ -44,20 +55,19 @@ namespace NoteScaler.Services
 			WriteInt16(outputStream, TicksPerQuarterNote);
 		}
 
-		private static void WriteTrack(Stream outputStream, IReadOnlyCollection<GuitarPerformanceEvent> performanceEvents)
+		private static void WriteTrack(Stream outputStream, IReadOnlyCollection<MidiNoteEvent> midiEvents)
 		{
 			using var trackStream = new MemoryStream();
 			WriteTempoEvent(trackStream);
 			WriteProgramChangeEvent(trackStream);
 
-			var midiEvents = performanceEvents
-				.SelectMany(CreateMidiEvents)
+			var orderedMidiEvents = midiEvents
 				.OrderBy(midiEvent => midiEvent.Tick)
 				.ThenBy(midiEvent => midiEvent.IsNoteOn ? 1 : 0)
 				.ToArray();
 
 			var previousTick = 0;
-			foreach (var midiEvent in midiEvents)
+			foreach (var midiEvent in orderedMidiEvents)
 			{
 				WriteVariableLengthQuantity(trackStream, midiEvent.Tick - previousTick);
 				trackStream.WriteByte((byte)(midiEvent.IsNoteOn ? 0x90 + MidiChannel : 0x80 + MidiChannel));
@@ -74,6 +84,27 @@ namespace NoteScaler.Services
 			trackStream.CopyTo(outputStream);
 		}
 
+		private static IEnumerable<MidiNoteEvent> CreateMidiEvents(IEnumerable<CompositeNote> compositeNotes)
+		{
+			var startTick = 0;
+			foreach (var compositeNote in compositeNotes)
+			{
+				var groupEvents = compositeNote.Notes
+					.Where(note => !note.Note.Equals("W", StringComparison.InvariantCultureIgnoreCase))
+					.SelectMany(note => CreateMidiEvents(note, startTick))
+					.ToArray();
+
+				foreach (var midiEvent in groupEvents)
+				{
+					yield return midiEvent;
+				}
+
+				startTick += compositeNote.Notes.Any()
+					? compositeNote.Notes.Max(note => note.Duration)
+					: 0;
+			}
+		}
+
 		private static IEnumerable<MidiNoteEvent> CreateMidiEvents(GuitarPerformanceEvent performanceEvent)
 		{
 			var noteNumber = GetMidiNoteNumber(performanceEvent.Note);
@@ -82,6 +113,15 @@ namespace NoteScaler.Services
 			var endTick = performanceEvent.StartOffsetMilliseconds + performanceEvent.DurationMilliseconds;
 
 			yield return new MidiNoteEvent(startTick, noteNumber, velocity, true);
+			yield return new MidiNoteEvent(endTick, noteNumber, 0, false);
+		}
+
+		private static IEnumerable<MidiNoteEvent> CreateMidiEvents(FrequencyDuration note, int startTick)
+		{
+			var noteNumber = GetMidiNoteNumber($"{note.Note}{note.Octave}");
+			var endTick = startTick + note.Duration;
+
+			yield return new MidiNoteEvent(startTick, noteNumber, DefaultVelocity, true);
 			yield return new MidiNoteEvent(endTick, noteNumber, 0, false);
 		}
 

--- a/NoteScaler/Services/NoteScalerRunner.cs
+++ b/NoteScaler/Services/NoteScalerRunner.cs
@@ -69,7 +69,7 @@ namespace NoteScaler.Services
 
 				PlayNoteAsRequired(options.Note, options.Octave.GetValueOrDefault(), a4Reference, playableSequence);
 				PlayTabAsRequired(tabName, options.ExportMidi, playableSequence);
-				PlaySongAsRequired(key, fileName, playableSequence);
+				PlaySongAsRequired(key, fileName, options.ExportMidi, playableSequence);
 			}
 			finally
 			{
@@ -172,7 +172,7 @@ namespace NoteScaler.Services
 			}
 		}
 
-		private void PlaySongAsRequired(string key, string fileName, PlayableSequence playableSequence)
+		private void PlaySongAsRequired(string key, string fileName, string exportMidi, PlayableSequence playableSequence)
 		{
 			if (!string.IsNullOrEmpty(fileName))
 			{
@@ -186,6 +186,7 @@ namespace NoteScaler.Services
 					var currentSong = GetTheSongByKeyAsRequired(key, song);
 					playableSequence.ConvertSongNotesToNoteSequence(currentSong);
 					playableSequence.Prepare();
+					ExportSequenceToMidiAsRequired(exportMidi, playableSequence.CompositeNotes);
 					playableSequence.Play();
 
 					if (song.Reverse)
@@ -235,6 +236,24 @@ namespace NoteScaler.Services
 			{
 				var performanceEvents = guitarPerformanceEventFactory.Create(stringInstrument, tabs, measureTime);
 				midiFileExporter.Export(performanceEvents, exportMidi);
+				consoleOutputService.WriteMessage($"Exported MIDI: {exportMidi}");
+			}
+			catch (Exception ex)
+			{
+				consoleOutputService.WriteMessage(ex.Message, ConsoleColor.Red);
+			}
+		}
+
+		private void ExportSequenceToMidiAsRequired(string exportMidi, IEnumerable<CompositeNote> compositeNotes)
+		{
+			if (string.IsNullOrWhiteSpace(exportMidi))
+			{
+				return;
+			}
+
+			try
+			{
+				midiFileExporter.ExportCompositeNotes(compositeNotes, exportMidi);
 				consoleOutputService.WriteMessage($"Exported MIDI: {exportMidi}");
 			}
 			catch (Exception ex)

--- a/NoteScalerTests/Services/MidiFileExporterTests.cs
+++ b/NoteScalerTests/Services/MidiFileExporterTests.cs
@@ -3,6 +3,7 @@ namespace NoteScalerTests.Services
 	using NoteScaler.Enums;
 	using NoteScaler.Models;
 	using NoteScaler.Services;
+	using NoteScalerTests.Support;
 	using System;
 	using System.IO;
 	using Xunit;
@@ -104,6 +105,43 @@ namespace NoteScalerTests.Services
 
 			var bytes = File.ReadAllBytes(outputPath);
 			AssertContains(bytes, new byte[] { 0x00, 0x90, 64, 100, 0x00, 0x90, 60, 100, 0x00, 0x90, 55, 100 });
+		}
+
+		[Fact]
+		public void ExportCompositeNotes_WritesSongSequenceNoteEvents()
+		{
+			var outputPath = Path.Combine(testDirectory, "song-sequence.mid");
+			var exporter = new MidiFileExporter();
+			var player = new TestPlayer();
+			var compositeNotes = new[]
+			{
+				new CompositeNote(InstrumentType.Horn, player, new[] { "C4-500" }),
+				new CompositeNote(InstrumentType.Horn, player, new[] { "D4-500" })
+			};
+
+			exporter.ExportCompositeNotes(compositeNotes, outputPath);
+
+			var bytes = File.ReadAllBytes(outputPath);
+			AssertContains(bytes, new byte[] { 0x00, 0x90, 60, 100 });
+			AssertContains(bytes, new byte[] { 0x83, 0x74, 0x80, 60, 0 });
+			AssertContains(bytes, new byte[] { 0x00, 0x90, 62, 100 });
+		}
+
+		[Fact]
+		public void ExportCompositeNotes_WhenChordIsPresent_WritesChordNotesAtSameTick()
+		{
+			var outputPath = Path.Combine(testDirectory, "song-chord.mid");
+			var exporter = new MidiFileExporter();
+			var player = new TestPlayer();
+			var compositeNotes = new[]
+			{
+				new CompositeNote(InstrumentType.Horn, player, new[] { "C4-500", "E4-500", "G4-500" })
+			};
+
+			exporter.ExportCompositeNotes(compositeNotes, outputPath);
+
+			var bytes = File.ReadAllBytes(outputPath);
+			AssertContains(bytes, new byte[] { 0x00, 0x90, 60, 100, 0x00, 0x90, 64, 100, 0x00, 0x90, 67, 100 });
 		}
 
 		[Fact]

--- a/NoteScalerTests/Services/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/Services/NoteScalerRunnerTests.cs
@@ -181,6 +181,20 @@ namespace NoteScalerTests.Services
 			Assert.True(harness.Player.PlayCount > 0);
 		}
 
+		[Fact]
+		public void Run_WhenExportMidiIsRequestedForSongFile_WritesMidiFileAndKeepsSongPlayback()
+		{
+			CreateSongWithoutKeyCollection("runner-midi-song");
+			var outputPath = Path.Combine(testDirectory, "runner-midi-song.mid");
+			var harness = CreateHarness();
+
+			harness.Runner.Run(new[] { "--file", "runner-midi-song", "--export-midi", outputPath, "--speed", "1500" });
+
+			Assert.True(File.Exists(outputPath));
+			Assert.Contains(harness.Console.Messages, message => message.Contains("Exported MIDI"));
+			Assert.True(harness.Player.PlayCount > 0);
+		}
+
 		public void Dispose()
 		{
 			Environment.CurrentDirectory = originalCurrentDirectory;

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Play a specific key/variation from a song file:
  dotnet run --project NoteScaler -- --file amazinggrace --key C
 ```
 
+Play a song file and export the converted note sequence to MIDI:
+
+```bash
+ dotnet run --project NoteScaler -- --file maryhadalittlelamb --export-midi mary.mid --speed 1500
+```
+
 Play a tab file named `anotherbrickinthewallpart2.json` from the `Tabs` directory:
 
 ```bash
@@ -131,7 +137,13 @@ When `--export-midi` is supplied with `--tab`, NoteScaler writes a standard `.mi
  dotnet run --project NoteScaler -- --tab anotherbrickinthewallpart2 --export-midi anotherbrickinthewallpart2.mid
 ```
 
-The MIDI file contains note-on and note-off events derived from the resolved tab string, fret, note, start offset, duration, velocity, and articulation metadata.
+When `--export-midi` is supplied with `--file`, NoteScaler writes a standard `.mid` file from the converted song note sequence and then continues normal song playback.
+
+```bash
+ dotnet run --project NoteScaler -- --file maryhadalittlelamb --export-midi mary.mid --speed 1500
+```
+
+The MIDI file contains note-on and note-off events derived from the resolved note sequence. Tab export uses guitar performance events. Song export uses the prepared composite note sequence that playback also consumes.
 
 ## Command-line options
 
@@ -146,7 +158,7 @@ The MIDI file contains note-on and note-off events derived from the resolved tab
 | `-n` | `--note` | `null` | Displays details for a note and plays its major, minor, and relative minor scales. |
 | `-f` | `--file` | `null` | Plays a JSON song file from the `Songs` directory. Pass the file name without `.json`. |
 | `-t` | `--tab` | `null` | Plays a JSON tab file from the `Tabs` directory. Pass the file name without `.json`. |
-|  | `--export-midi` | `null` | Writes a MIDI file when playing a tab. |
+|  | `--export-midi` | `null` | Writes a MIDI file when playing a tab or song file. |
 
 ## Operation order
 
@@ -157,7 +169,7 @@ When multiple operation options are supplied, NoteScaler processes them in this 
 3. Create the playable sequence.
 4. Process `--note` if supplied.
 5. Process `--tab` if supplied. The tab `tuning` value is resolved from the embedded base catalog plus the editable supplemental catalog. If `--export-midi` is supplied, a MIDI file is written before tab playback.
-6. Process `--file` if supplied.
+6. Process `--file` if supplied. If `--export-midi` is supplied, a MIDI file is written before song playback.
 
 That means a command can technically include more than one operation option, but the clearest usage is to run one primary operation at a time: `--note`, `--tab`, or `--file`.
 
@@ -200,9 +212,13 @@ flowchart TD
     X -->|Yes| Y[Load song file from Songs]
     Y --> AA{Song loaded?}
     AA -->|Yes| AB[Select requested/default key]
-    AB --> AC[Prepare and play song sequence]
-    AA -->|No| AD[Write song load error]
+    AB --> AC[Prepare song sequence]
+    AC --> AD{--export-midi supplied?}
+    AD -->|Yes| AE[Write MIDI file]
+    AD -->|No| AF[Play song sequence]
+    AE --> AF
+    AA -->|No| AG[Write song load error]
     X -->|No| Z[Exit]
-    AC --> Z
-    AD --> Z
+    AF --> Z
+    AG --> Z
 ```


### PR DESCRIPTION
## Summary

Resolves #60.

Adds MIDI export for song files played with `--file`, so this now works:

```text
notescaler --file maryhadalittlelamb --export-midi mary.mid --speed 1500
```

## What changed

- Added a shared `IMidiFileExporter.ExportCompositeNotes(...)` path.
- Reused `PlayableSequence.CompositeNotes` for song MIDI export instead of re-parsing song JSON.
- Wired `--file ... --export-midi ...` through the song playback path.
- Kept existing song playback behavior unchanged.
- Kept existing tab MIDI export behavior unchanged.
- Added MIDI exporter tests for composite note sequences and chord groups.
- Added a runner test proving song MIDI export writes a file and still plays the song.
- Updated README usage, option description, and flow chart.

## Design note

Tab export still uses `GuitarPerformanceEvent` so tab-specific metadata is preserved. Song export now uses the prepared `CompositeNote` sequence because that is the same shared representation consumed by playback.

## Validation

Local tests were not run because this environment does not have the .NET SDK. CI should validate the branch.

No merge to master. Scott will review and merge if approved.