### PR TITLE
Dump converted tab string for diagnostics

### DIFF
--- a/NoteScaler/Config/NoteScalerOptions.cs
+++ b/NoteScaler/Config/NoteScalerOptions.cs
@@ -37,6 +37,9 @@
 		[Option("gtab", Default = null, HelpText = "Name or path of the .gtab file to play from the GTabs directory.")]
 		public string Gtab { get; set; }
 
+		[Option("dump-tab", Default = false, HelpText = "Writes the converted NoteScaler tab string before tab or .gtab playback.")]
+		public bool DumpTab { get; set; }
+
 		[Option("export-midi", Default = null, HelpText = "Path to a MIDI file to export when playing a tab, .gtab file, or song file.")]
 		public string ExportMidi { get; set; }
 	}

--- a/NoteScaler/Services/NoteScalerRunner.cs
+++ b/NoteScaler/Services/NoteScalerRunner.cs
@@ -82,8 +82,8 @@ namespace NoteScaler.Services
 				playableSequence.PlayableSequenceEvent += PlayableSequence_PlayableSequenceEvent;
 
 				PlayNoteAsRequired(options.Note, options.Octave.GetValueOrDefault(), a4Reference, playableSequence);
-				PlayTabAsRequired(tabName, options.ExportMidi, playableSequence);
-				PlayGtabAsRequired(gtabName, options.ExportMidi, playableSequence);
+				PlayTabAsRequired(tabName, options.ExportMidi, options.DumpTab, playableSequence);
+				PlayGtabAsRequired(gtabName, options.ExportMidi, options.DumpTab, playableSequence);
 				PlaySongAsRequired(key, fileName, options.ExportMidi, playableSequence);
 			}
 			finally
@@ -214,7 +214,7 @@ namespace NoteScaler.Services
 			}
 		}
 
-		private void PlayTabAsRequired(string tabName, string exportMidi, PlayableSequence playableSequence)
+		private void PlayTabAsRequired(string tabName, string exportMidi, bool dumpTab, PlayableSequence playableSequence)
 		{
 			if (!string.IsNullOrEmpty(tabName))
 			{
@@ -225,12 +225,12 @@ namespace NoteScaler.Services
 				}
 				else
 				{
-					PlayTablature(tabs, exportMidi, playableSequence);
+					PlayTablature(tabs, exportMidi, dumpTab, playableSequence);
 				}
 			}
 		}
 
-		private void PlayGtabAsRequired(string gtabName, string exportMidi, PlayableSequence playableSequence)
+		private void PlayGtabAsRequired(string gtabName, string exportMidi, bool dumpTab, PlayableSequence playableSequence)
 		{
 			if (!string.IsNullOrEmpty(gtabName))
 			{
@@ -241,14 +241,15 @@ namespace NoteScaler.Services
 				}
 				else
 				{
-					PlayTablature(tabs, exportMidi, playableSequence);
+					PlayTablature(tabs, exportMidi, dumpTab, playableSequence);
 				}
 			}
 		}
 
-		private void PlayTablature(Tablature tabs, string exportMidi, PlayableSequence playableSequence)
+		private void PlayTablature(Tablature tabs, string exportMidi, bool dumpTab, PlayableSequence playableSequence)
 		{
 			tabs.FixUp();
+			DumpTabAsRequired(dumpTab, tabs);
 			var stringInstrument = CreateStringInstrumentForTab(tabs);
 			if (stringInstrument == null)
 			{
@@ -260,6 +261,14 @@ namespace NoteScaler.Services
 			playableSequence.Repeat = tabs.Repeat;
 			playableSequence.Prepare();
 			playableSequence.Play();
+		}
+
+		private void DumpTabAsRequired(bool dumpTab, Tablature tabs)
+		{
+			if (dumpTab)
+			{
+				consoleOutputService.WriteMessage($"Converted NoteScaler tab: {tabs.TabString}");
+			}
 		}
 
 		private void ExportTabToMidiAsRequired(string exportMidi, IStringInstrument stringInstrument, Tablature tabs, int measureTime)

--- a/NoteScalerTests/Services/NoteScalerRunnerTests.cs
+++ b/NoteScalerTests/Services/NoteScalerRunnerTests.cs
@@ -140,7 +140,20 @@ namespace NoteScalerTests.Services
 			harness.Runner.Run(new[] { "--gtab", "runner-gtab.gtab" });
 
 			Assert.Contains(harness.Console.Messages, message => message.Contains("Using string instrument: Standard"));
+			Assert.False(harness.Console.Messages.Any(message => message.Contains("Converted NoteScaler tab:")));
 			Assert.NotNull(harness.Factory.CreatedSequence);
+			Assert.True(harness.Player.PlayCount > 0);
+		}
+
+		[Fact]
+		public void Run_WhenDumpTabIsRequestedForGtabFile_WritesConvertedTabStringAndKeepsGtabPlayback()
+		{
+			CreateGtabFile("runner-gtab.gtab", "Standard");
+			var harness = CreateHarness();
+
+			harness.Runner.Run(new[] { "--gtab", "runner-gtab.gtab", "--dump-tab" });
+
+			Assert.Contains(harness.Console.Messages, message => message.Contains("Converted NoteScaler tab: 4-2,5-0"));
 			Assert.True(harness.Player.PlayCount > 0);
 		}
 
@@ -153,6 +166,21 @@ namespace NoteScalerTests.Services
 
 			harness.Runner.Run(new[] { "--gtab", "runner-midi-gtab.gtab", "--export-midi", outputPath });
 
+			Assert.True(File.Exists(outputPath));
+			Assert.Contains(harness.Console.Messages, message => message.Contains("Exported MIDI"));
+			Assert.True(harness.Player.PlayCount > 0);
+		}
+
+		[Fact]
+		public void Run_WhenDumpTabAndExportMidiAreRequestedForGtabFile_WritesDumpMidiAndKeepsPlayback()
+		{
+			CreateGtabFile("runner-dump-midi-gtab.gtab", "Standard");
+			var outputPath = Path.Combine(testDirectory, "runner-dump-midi-gtab.mid");
+			var harness = CreateHarness();
+
+			harness.Runner.Run(new[] { "--gtab", "runner-dump-midi-gtab.gtab", "--dump-tab", "--export-midi", outputPath });
+
+			Assert.Contains(harness.Console.Messages, message => message.Contains("Converted NoteScaler tab: 4-2,5-0"));
 			Assert.True(File.Exists(outputPath));
 			Assert.Contains(harness.Console.Messages, message => message.Contains("Exported MIDI"));
 			Assert.True(harness.Player.PlayCount > 0);

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Play a Guitar Tab Maker `.gtab` file named `maryhadalittlelamb.gtab` from the `G
  dotnet run --project NoteScaler -- --gtab maryhadalittlelamb
 ```
 
+Dump the converted NoteScaler tab string for a `.gtab` file before playback:
+
+```bash
+ dotnet run --project NoteScaler -- --gtab maryhadalittlelamb --dump-tab
+```
+
 Play a `.gtab` file and export it to MIDI:
 
 ```bash
@@ -175,6 +181,8 @@ The first supported shape looks like this:
 
 The required fields are `title`, `stringNotes`, and `tabRows`. The loader uses numeric `p` values as frets, treats `—` as an empty string cell, ignores non-numeric technique markers in this first slice, and maps known `stringNotes` arrays such as `E,A,D,G,B,E` to existing NoteScaler tunings. Empty columns between fretted columns, plus trailing empty columns, are folded into duration multipliers. `tempo` is captured, but current playback timing still comes from the command-line `--speed` option. Both sharp and flat aliases are recognized for the currently supported lowered standard tunings.
 
+Use `--dump-tab` with `--gtab` to print the converted NoteScaler tab string before playback. This is useful when a `.gtab` file sounds wrong and you need to inspect the intermediate conversion.
+
 See `docs/gtab-schema.md` for the detailed Guitar Tab Maker adapter notes.
 
 ## MIDI export
@@ -215,6 +223,7 @@ The MIDI file contains note-on and note-off events derived from the resolved not
 | `-f` | `--file` | `null` | Plays a JSON song file from the `Songs` directory. Pass the file name without `.json`. |
 | `-t` | `--tab` | `null` | Plays a JSON tab file from the `Tabs` directory. Pass the file name without `.json`. |
 |  | `--gtab` | `null` | Plays a Guitar Tab Maker `.gtab` file from the `GTabs` directory or from an explicit path. The `.gtab` extension is optional. |
+|  | `--dump-tab` | `false` | Writes the converted NoteScaler tab string before tab or `.gtab` playback. |
 |  | `--export-midi` | `null` | Writes a MIDI file when playing a tab, `.gtab`, or song file. |
 
 ## Operation order
@@ -225,8 +234,8 @@ When multiple operation options are supplied, NoteScaler processes them in this 
 2. Apply `--prewait` if configured.
 3. Create the playable sequence.
 4. Process `--note` if supplied.
-5. Process `--tab` if supplied. The tab `tuning` value is resolved from the embedded base catalog plus the editable supplemental catalog. If `--export-midi` is supplied, a MIDI file is written before tab playback.
-6. Process `--gtab` if supplied. The Guitar Tab Maker `.gtab` document is normalized into the existing tablature path. If `--export-midi` is supplied, a MIDI file is written before `.gtab` playback.
+5. Process `--tab` if supplied. The tab `tuning` value is resolved from the embedded base catalog plus the editable supplemental catalog. If `--dump-tab` is supplied, the normalized tab string is written before playback. If `--export-midi` is supplied, a MIDI file is written before tab playback.
+6. Process `--gtab` if supplied. The Guitar Tab Maker `.gtab` document is normalized into the existing tablature path. If `--dump-tab` is supplied, the converted NoteScaler tab string is written before playback. If `--export-midi` is supplied, a MIDI file is written before `.gtab` playback.
 7. Process `--file` if supplied. If `--export-midi` is supplied, a MIDI file is written before song playback.
 
 That means a command can technically include more than one operation option, but the clearest usage is to run one primary operation at a time: `--note`, `--tab`, `--gtab`, or `--file`.


### PR DESCRIPTION
## Summary

Resolves #63.

Adds a small `--dump-tab` diagnostic option so `.gtab` conversion can be inspected before playback or MIDI export.

## What changed

- Add `--dump-tab` command-line option.
- Write `Converted NoteScaler tab: ...` after tab normalization and before playback/export.
- Reuse the same `Tablature.TabString` that flows into the existing tab playback and MIDI paths.
- Keep normal output unchanged when `--dump-tab` is omitted.
- Add runner tests for:
  - no diagnostic output by default
  - `.gtab --dump-tab` prints the converted tab string and still plays
  - `.gtab --dump-tab --export-midi` prints the converted tab string, writes MIDI, and still plays
- Update README usage and command-line options.

## Validation

CI should validate the branch.

No merge to master. Scott will review and merge if approved.